### PR TITLE
feat: add order status validation

### DIFF
--- a/src/interfaces/ReactorStructs.sol
+++ b/src/interfaces/ReactorStructs.sol
@@ -31,9 +31,16 @@ struct ResolvedOrder {
 }
 
 struct OrderFill {
+    ResolvedOrder order;
     Signature sig;
     address permitPost;
     bytes32 orderHash;
     address fillContract;
     bytes fillData;
+}
+
+struct OrderStatus {
+    bool isCancelled;
+    // TODO: use numerator/denominator for partial fills
+    bool isFilled;
 }

--- a/src/lib/OrderFiller.sol
+++ b/src/lib/OrderFiller.sol
@@ -13,30 +13,28 @@ import {
 
 library OrderFiller {
     /// @notice fill an order
-    function fill(ResolvedOrder memory order, OrderFill memory orderFill)
-        internal
-    {
+    function fill(OrderFill memory orderFill) internal {
         IPermitPost(orderFill.permitPost).saltTransferFrom(
             Permit({
-                token: order.input.token,
+                token: orderFill.order.input.token,
                 spender: address(this),
-                maxAmount: order.input.amount,
-                deadline: order.info.deadline
+                maxAmount: orderFill.order.input.amount,
+                deadline: orderFill.order.info.deadline
             }),
-            order.info.offerer,
+            orderFill.order.info.offerer,
             orderFill.fillContract,
-            order.input.amount,
+            orderFill.order.input.amount,
             orderFill.orderHash,
             orderFill.sig
         );
 
         IReactorCallback(orderFill.fillContract).reactorCallback(
-            order.outputs, orderFill.fillData
+            orderFill.order.outputs, orderFill.fillData
         );
 
         // transfer output tokens to their respective recipients
-        for (uint256 i = 0; i < order.outputs.length; i++) {
-            Output memory output = order.outputs[i];
+        for (uint256 i = 0; i < orderFill.order.outputs.length; i++) {
+            Output memory output = orderFill.order.outputs[i];
             ERC20(output.token).transferFrom(
                 orderFill.fillContract, output.recipient, output.amount
             );

--- a/src/reactor/BaseReactor.sol
+++ b/src/reactor/BaseReactor.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {OrderFiller} from "../lib/OrderFiller.sol";
+import {OrderValidator} from "../lib/OrderValidator.sol";
+import {
+    ResolvedOrder,
+    OrderFill,
+    OrderInfo,
+    OrderStatus,
+    TokenAmount
+} from "../interfaces/ReactorStructs.sol";
+
+/// @notice Reactor for simple limit orders
+contract BaseReactor {
+    using OrderFiller for OrderFill;
+    using OrderValidator for mapping(bytes32 => OrderStatus);
+    using OrderValidator for OrderInfo;
+
+    address public immutable permitPost;
+
+    mapping(bytes32 => OrderStatus) public orderStatus;
+
+    constructor(address _permitPost) {
+        permitPost = _permitPost;
+    }
+
+    /// @notice validates and fills an order, marking it as filled
+    function fill(OrderFill memory orderFill) internal {
+        orderFill.order.info.validate();
+        orderStatus.updateFilled(orderFill.orderHash);
+        orderFill.fill();
+    }
+}

--- a/src/test/MockOrderValidator.sol
+++ b/src/test/MockOrderValidator.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {OrderValidator} from "../lib/OrderValidator.sol";
+import {OrderInfo, OrderStatus} from "../interfaces/ReactorStructs.sol";
+import {IValidationCallback} from "../interfaces/IValidationCallback.sol";
+
+contract MockOrderValidator {
+    using OrderValidator for OrderInfo;
+    using OrderValidator for mapping(bytes32 => OrderStatus);
+
+    mapping(bytes32 => OrderStatus) public orderStatus;
+
+    function validate(OrderInfo memory info) external view {
+        info.validate();
+    }
+
+    function updateFilled(bytes32 orderHash) external {
+        orderStatus.updateFilled(orderHash);
+    }
+
+    function updateCancelled(bytes32 orderHash) external {
+        orderStatus.updateCancelled(orderHash);
+    }
+
+    function getOrderStatus(bytes32 orderHash)
+        external
+        returns (OrderStatus memory)
+    {
+        return orderStatus[orderHash];
+    }
+}

--- a/test/libraries/OrderValidator.t.sol
+++ b/test/libraries/OrderValidator.t.sol
@@ -5,27 +5,28 @@ import {Test} from "forge-std/Test.sol";
 import {OrderInfo} from "../../src/interfaces/ReactorStructs.sol";
 import {OrderValidator} from "../../src/lib/OrderValidator.sol";
 import {MockValidationContract} from "../../src/test/MockValidationContract.sol";
+import {MockOrderValidator} from "../../src/test/MockOrderValidator.sol";
 import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
 
 contract OrderValidatorTest is Test {
     using OrderInfoBuilder for OrderInfo;
 
-    OrderValidator validator;
+    MockOrderValidator validator;
 
     function setUp() public {
-        validator = new OrderValidator();
+        validator = new MockOrderValidator();
     }
 
     function testInvalidReactor() public {
         vm.expectRevert(OrderValidator.InvalidReactor.selector);
-        validator.validateOrderInfo(OrderInfoBuilder.init(address(0)));
+        validator.validate(OrderInfoBuilder.init(address(0)));
     }
 
     function testDeadlinePassed() public {
         vm.expectRevert(OrderValidator.DeadlinePassed.selector);
         uint256 timestamp = block.timestamp;
         vm.warp(timestamp + 100);
-        validator.validateOrderInfo(
+        validator.validate(
             OrderInfoBuilder.init(address(validator)).withDeadline(block.timestamp - 1)
         );
     }
@@ -34,23 +35,65 @@ contract OrderValidatorTest is Test {
         MockValidationContract validationContract = new MockValidationContract();
         validationContract.setValid(false);
         vm.expectRevert(OrderValidator.InvalidOrder.selector);
-        validator.validateOrderInfo(
+        validator.validate(
             OrderInfoBuilder.init(address(validator)).withDeadline(block.timestamp)
                 .withValidationContract(address(validationContract))
         );
     }
 
     function testValid() public view {
-        validator.validateOrderInfo(OrderInfoBuilder.init(address(validator)));
+        validator.validate(OrderInfoBuilder.init(address(validator)));
     }
 
     function testValidationContractValid() public {
         MockValidationContract validationContract = new MockValidationContract();
         validationContract.setValid(true);
-        validator.validateOrderInfo(
+        validator.validate(
             OrderInfoBuilder.init(address(validator)).withValidationContract(
                 address(validationContract)
             )
         );
+    }
+
+    function testUpdateFilled() public {
+        bytes32 orderHash = keccak256("test");
+        validator.updateFilled(orderHash);
+        assertTrue(validator.getOrderStatus(orderHash).isFilled);
+        assertFalse(validator.getOrderStatus(orderHash).isCancelled);
+    }
+
+    function testUpdateFilledWhenCancelled() public {
+        bytes32 orderHash = keccak256("test");
+        validator.updateCancelled(orderHash);
+        vm.expectRevert(OrderValidator.OrderCancelled.selector);
+        validator.updateFilled(orderHash);
+    }
+
+    function testUpdateFilledWhenAlreadyFilled() public {
+        bytes32 orderHash = keccak256("test");
+        validator.updateFilled(orderHash);
+        vm.expectRevert(OrderValidator.OrderAlreadyFilled.selector);
+        validator.updateFilled(orderHash);
+    }
+
+    function testUpdateCancelled() public {
+        bytes32 orderHash = keccak256("test");
+        validator.updateCancelled(orderHash);
+        assertFalse(validator.getOrderStatus(orderHash).isFilled);
+        assertTrue(validator.getOrderStatus(orderHash).isCancelled);
+    }
+
+    function testUpdateCancelledWhenAlreadyCancelled() public {
+        bytes32 orderHash = keccak256("test");
+        validator.updateCancelled(orderHash);
+        vm.expectRevert(OrderValidator.OrderCancelled.selector);
+        validator.updateCancelled(orderHash);
+    }
+
+    function testUpdateCancelledWhenAlreadyFilled() public {
+        bytes32 orderHash = keccak256("test");
+        validator.updateFilled(orderHash);
+        vm.expectRevert(OrderValidator.OrderAlreadyFilled.selector);
+        validator.updateCancelled(orderHash);
     }
 }


### PR DESCRIPTION
This commit adds order status validation, enforcing that orders cannot
be executed twice and can't be executed at all if they have been
cancelled by the user.

Also adds BaseReactor contract which includes some shared logic that
should be run by all reactors on fill. Ordertype-specific reactors
should only validate the ordertype-specific data and resolve into the
generic order struct. This way we can ideally run as many critical flows
through the base reactor.