### PR TITLE
feat: remove limit order struct

### DIFF
--- a/src/reactors/LimitOrderReactor.sol
+++ b/src/reactors/LimitOrderReactor.sol
@@ -4,24 +4,13 @@ pragma solidity ^0.8.16;
 import {BaseReactor} from "./BaseReactor.sol";
 import {ResolvedOrder, OrderInfo, InputToken, OutputToken} from "../base/ReactorStructs.sol";
 
-/// @dev External struct used to specify simple limit orders
-struct LimitOrder {
-    // generic order information
-    OrderInfo info;
-    // The tokens that the offerer will provide when settling the order
-    InputToken input;
-    // The tokens that must be received to satisfy the order
-    OutputToken[] outputs;
-}
-
 /// @notice Reactor for simple limit orders
 contract LimitOrderReactor is BaseReactor {
     constructor(address _permitPost) BaseReactor(_permitPost) {}
 
-    /// @notice Resolve a LimitOrder into a generic order
+    /// @notice Resolve the encoded order into a generic order
     /// @dev limit order inputs and outputs are directly specified
     function resolve(bytes memory order) internal pure override returns (ResolvedOrder memory resolvedOrder) {
-        LimitOrder memory limitOrder = abi.decode(order, (LimitOrder));
-        resolvedOrder = ResolvedOrder({info: limitOrder.info, input: limitOrder.input, outputs: limitOrder.outputs});
+        resolvedOrder = abi.decode(order, (ResolvedOrder));
     }
 }

--- a/test/lib/OrderQuoter.t.sol
+++ b/test/lib/OrderQuoter.t.sol
@@ -11,7 +11,7 @@ import {OrderQuoter} from "../../src/lens/OrderQuoter.sol";
 import {MockERC20} from "../util/mock/MockERC20.sol";
 import {MockMaker} from "../util/mock/users/MockMaker.sol";
 import {MockFillContract} from "../util/mock/MockFillContract.sol";
-import {LimitOrderReactor, LimitOrder} from "../../src/reactors/LimitOrderReactor.sol";
+import {LimitOrderReactor} from "../../src/reactors/LimitOrderReactor.sol";
 import {DutchLimitOrderReactor, DutchLimitOrder, DutchOutput} from "../../src/reactors/DutchLimitOrderReactor.sol";
 import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
 import {OutputsBuilder} from "../util/OutputsBuilder.sol";
@@ -45,7 +45,7 @@ contract OrderQuoterTest is Test, PermitSignature, ReactorEvents {
 
     function testQuoteLimitOrder() public {
         tokenIn.forceApprove(maker, address(permitPost), ONE);
-        LimitOrder memory order = LimitOrder({
+        ResolvedOrder memory order = ResolvedOrder({
             info: OrderInfoBuilder.init(address(limitOrderReactor)).withOfferer(address(maker)),
             input: InputToken(address(tokenIn), ONE),
             outputs: OutputsBuilder.single(address(tokenOut), ONE, address(maker))
@@ -104,7 +104,7 @@ contract OrderQuoterTest is Test, PermitSignature, ReactorEvents {
         uint256 timestamp = block.timestamp;
         vm.warp(timestamp + 100);
         tokenIn.forceApprove(maker, address(permitPost), ONE);
-        LimitOrder memory order = LimitOrder({
+        ResolvedOrder memory order = ResolvedOrder({
             info: OrderInfoBuilder.init(address(limitOrderReactor)).withOfferer(address(maker)).withDeadline(
                 block.timestamp - 1
                 ),
@@ -119,7 +119,7 @@ contract OrderQuoterTest is Test, PermitSignature, ReactorEvents {
 
     function testQuoteLimitOrderInsufficientBalance() public {
         tokenIn.forceApprove(maker, address(permitPost), ONE);
-        LimitOrder memory order = LimitOrder({
+        ResolvedOrder memory order = ResolvedOrder({
             info: OrderInfoBuilder.init(address(limitOrderReactor)).withOfferer(address(maker)),
             input: InputToken(address(tokenIn), ONE * 2),
             outputs: OutputsBuilder.single(address(tokenOut), ONE, address(maker))

--- a/test/reactors/LimitOrderReactor.t.sol
+++ b/test/reactors/LimitOrderReactor.t.sol
@@ -9,7 +9,7 @@ import {ReactorEvents} from "../../src/base/ReactorEvents.sol";
 import {MockERC20} from "../util/mock/MockERC20.sol";
 import {MockMaker} from "../util/mock/users/MockMaker.sol";
 import {MockFillContract} from "../util/mock/MockFillContract.sol";
-import {LimitOrderReactor, LimitOrder} from "../../src/reactors/LimitOrderReactor.sol";
+import {LimitOrderReactor} from "../../src/reactors/LimitOrderReactor.sol";
 import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
 import {OutputsBuilder} from "../util/OutputsBuilder.sol";
 import {PermitSignature} from "../util/PermitSignature.sol";
@@ -41,7 +41,7 @@ contract LimitOrderReactorTest is Test, PermitSignature, ReactorEvents {
 
     function testExecute() public {
         tokenIn.forceApprove(maker, address(permitPost), ONE);
-        LimitOrder memory order = LimitOrder({
+        ResolvedOrder memory order = ResolvedOrder({
             info: OrderInfoBuilder.init(address(reactor)).withOfferer(address(maker)),
             input: InputToken(address(tokenIn), ONE),
             outputs: OutputsBuilder.single(address(tokenOut), ONE, address(maker))
@@ -68,7 +68,7 @@ contract LimitOrderReactorTest is Test, PermitSignature, ReactorEvents {
     function testExecuteNonceReuse() public {
         tokenIn.forceApprove(maker, address(permitPost), ONE);
         uint256 nonce = 1234;
-        LimitOrder memory order = LimitOrder({
+        ResolvedOrder memory order = ResolvedOrder({
             info: OrderInfoBuilder.init(address(reactor)).withOfferer(address(maker)).withNonce(nonce),
             input: InputToken(address(tokenIn), ONE),
             outputs: OutputsBuilder.single(address(tokenOut), ONE, address(maker))
@@ -80,7 +80,7 @@ contract LimitOrderReactorTest is Test, PermitSignature, ReactorEvents {
         tokenIn.mint(address(maker), ONE * 2);
         tokenOut.mint(address(fillContract), ONE * 2);
         tokenIn.forceApprove(maker, address(permitPost), ONE * 2);
-        LimitOrder memory order2 = LimitOrder({
+        ResolvedOrder memory order2 = ResolvedOrder({
             info: OrderInfoBuilder.init(address(reactor)).withOfferer(address(maker)).withNonce(nonce),
             input: InputToken(address(tokenIn), ONE * 2),
             outputs: OutputsBuilder.single(address(tokenOut), ONE * 2, address(maker))
@@ -94,7 +94,7 @@ contract LimitOrderReactorTest is Test, PermitSignature, ReactorEvents {
 
     function testExecuteInsufficientPermit() public {
         tokenIn.forceApprove(maker, address(permitPost), ONE);
-        LimitOrder memory order = LimitOrder({
+        ResolvedOrder memory order = ResolvedOrder({
             info: OrderInfoBuilder.init(address(reactor)).withOfferer(address(maker)),
             input: InputToken(address(tokenIn), ONE),
             outputs: OutputsBuilder.single(address(tokenOut), ONE, address(maker))
@@ -110,7 +110,7 @@ contract LimitOrderReactorTest is Test, PermitSignature, ReactorEvents {
 
     function testExecuteIncorrectSpender() public {
         tokenIn.forceApprove(maker, address(permitPost), ONE);
-        LimitOrder memory order = LimitOrder({
+        ResolvedOrder memory order = ResolvedOrder({
             info: OrderInfoBuilder.init(address(reactor)).withOfferer(address(maker)),
             input: InputToken(address(tokenIn), ONE),
             outputs: OutputsBuilder.single(address(tokenOut), ONE, address(maker))
@@ -131,7 +131,7 @@ contract LimitOrderReactorTest is Test, PermitSignature, ReactorEvents {
 
     function testExecuteIncorrectToken() public {
         tokenIn.forceApprove(maker, address(permitPost), ONE);
-        LimitOrder memory order = LimitOrder({
+        ResolvedOrder memory order = ResolvedOrder({
             info: OrderInfoBuilder.init(address(reactor)).withOfferer(address(maker)),
             input: InputToken(address(tokenIn), ONE),
             outputs: OutputsBuilder.single(address(tokenOut), ONE, address(maker))


### PR DESCRIPTION
It's exactly the same as the resolvedorder internal struct so just use that instead