### PR TITLE
fix: compiler warnings

### DIFF
--- a/test/util/mock/MockValidationContract.sol
+++ b/test/util/mock/MockValidationContract.sol
@@ -10,7 +10,7 @@ contract MockValidationContract is IValidationCallback {
         valid = _valid;
     }
 
-    function validate(address filler, ResolvedOrder memory resolvedOrder) external view returns (bool) {
+    function validate(address, ResolvedOrder memory) external view returns (bool) {
         return valid;
     }
 }

--- a/test/validation-contracts/ExclusiveFillerValidation.t.sol
+++ b/test/validation-contracts/ExclusiveFillerValidation.t.sol
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.16;
+
 import {GasSnapshot} from "forge-gas-snapshot/GasSnapshot.sol";
 import {Test} from "forge-std/Test.sol";
 import {DeployPermit2} from "../util/DeployPermit2.sol";


### PR DESCRIPTION
This commit fixes a couple compiler warnings - missing pragma on a test file and unused params