### PR TITLE
delete the wrong description for execute and executeBatch in sample-executors /SwapRouter02Executor.sol?

### DIFF
--- a/src/sample-executors/SwapRouter02Executor.sol
+++ b/src/sample-executors/SwapRouter02Executor.sol
@@ -49,12 +49,10 @@ contract SwapRouter02Executor is IReactorCallback, Owned {
         weth = WETH(payable(_swapRouter02.WETH9()));
     }
 
-    /// @notice assume that we already have all output tokens
     function execute(SignedOrder calldata order, bytes calldata callbackData) external onlyWhitelistedCaller {
         reactor.executeWithCallback(order, callbackData);
     }
 
-    /// @notice assume that we already have all output tokens
     function executeBatch(SignedOrder[] calldata orders, bytes calldata callbackData) external onlyWhitelistedCaller {
         reactor.executeBatchWithCallback(orders, callbackData);
     }


### PR DESCRIPTION
In the case of the Direct Filler, fillers need to own output tokens in advance. However, they don’t need to have them when they use their strategies in the filler contract. That’s why the description for both functions execute and executeBatch in the SwapRouter02Executor.sol file has been deleted in this pull request.