### PR TITLE
feat: use consistent naming for internals

### DIFF
--- a/src/reactors/BaseReactor.sol
+++ b/src/reactors/BaseReactor.sol
@@ -34,7 +34,7 @@ abstract contract BaseReactor is IReactor, ReactorEvents, ProtocolFees, Reentran
     /// @inheritdoc IReactor
     function execute(SignedOrder calldata order) external payable override nonReentrant {
         ResolvedOrder[] memory resolvedOrders = new ResolvedOrder[](1);
-        resolvedOrders[0] = resolve(order);
+        resolvedOrders[0] = _resolve(order);
 
         _prepare(resolvedOrders);
         _fill(resolvedOrders);
@@ -48,7 +48,7 @@ abstract contract BaseReactor is IReactor, ReactorEvents, ProtocolFees, Reentran
         nonReentrant
     {
         ResolvedOrder[] memory resolvedOrders = new ResolvedOrder[](1);
-        resolvedOrders[0] = resolve(order);
+        resolvedOrders[0] = _resolve(order);
 
         _prepare(resolvedOrders);
         IReactorCallback(msg.sender).reactorCallback(resolvedOrders, callbackData);
@@ -62,7 +62,7 @@ abstract contract BaseReactor is IReactor, ReactorEvents, ProtocolFees, Reentran
 
         unchecked {
             for (uint256 i = 0; i < ordersLength; i++) {
-                resolvedOrders[i] = resolve(orders[i]);
+                resolvedOrders[i] = _resolve(orders[i]);
             }
         }
 
@@ -82,7 +82,7 @@ abstract contract BaseReactor is IReactor, ReactorEvents, ProtocolFees, Reentran
 
         unchecked {
             for (uint256 i = 0; i < ordersLength; i++) {
-                resolvedOrders[i] = resolve(orders[i]);
+                resolvedOrders[i] = _resolve(orders[i]);
             }
         }
 
@@ -100,7 +100,7 @@ abstract contract BaseReactor is IReactor, ReactorEvents, ProtocolFees, Reentran
                 ResolvedOrder memory order = orders[i];
                 _injectFees(order);
                 order.validate(msg.sender);
-                transferInputTokens(order, msg.sender);
+                _transferInputTokens(order, msg.sender);
             }
         }
     }
@@ -140,10 +140,10 @@ abstract contract BaseReactor is IReactor, ReactorEvents, ProtocolFees, Reentran
     /// @param order The encoded order to resolve
     /// @return resolvedOrder generic resolved order of inputs and outputs
     /// @dev should revert on any order-type-specific validation errors
-    function resolve(SignedOrder calldata order) internal view virtual returns (ResolvedOrder memory resolvedOrder);
+    function _resolve(SignedOrder calldata order) internal view virtual returns (ResolvedOrder memory resolvedOrder);
 
     /// @notice Transfers tokens to the fillContract
     /// @param order The encoded order to transfer tokens for
     /// @param to The address to transfer tokens to
-    function transferInputTokens(ResolvedOrder memory order, address to) internal virtual;
+    function _transferInputTokens(ResolvedOrder memory order, address to) internal virtual;
 }

--- a/src/reactors/DutchOrderReactor.sol
+++ b/src/reactors/DutchOrderReactor.sol
@@ -24,7 +24,7 @@ contract DutchOrderReactor is BaseReactor {
     constructor(IPermit2 _permit2, address _protocolFeeOwner) BaseReactor(_permit2, _protocolFeeOwner) {}
 
     /// @inheritdoc BaseReactor
-    function resolve(SignedOrder calldata signedOrder)
+    function _resolve(SignedOrder calldata signedOrder)
         internal
         view
         virtual
@@ -44,7 +44,7 @@ contract DutchOrderReactor is BaseReactor {
     }
 
     /// @inheritdoc BaseReactor
-    function transferInputTokens(ResolvedOrder memory order, address to) internal override {
+    function _transferInputTokens(ResolvedOrder memory order, address to) internal override {
         permit2.permitWitnessTransferFrom(
             order.toPermit(),
             order.transferDetails(to),

--- a/src/reactors/ExclusiveDutchOrderReactor.sol
+++ b/src/reactors/ExclusiveDutchOrderReactor.sol
@@ -26,7 +26,7 @@ contract ExclusiveDutchOrderReactor is BaseReactor {
     constructor(IPermit2 _permit2, address _protocolFeeOwner) BaseReactor(_permit2, _protocolFeeOwner) {}
 
     /// @inheritdoc BaseReactor
-    function resolve(SignedOrder calldata signedOrder)
+    function _resolve(SignedOrder calldata signedOrder)
         internal
         view
         virtual
@@ -47,7 +47,7 @@ contract ExclusiveDutchOrderReactor is BaseReactor {
     }
 
     /// @inheritdoc BaseReactor
-    function transferInputTokens(ResolvedOrder memory order, address to) internal override {
+    function _transferInputTokens(ResolvedOrder memory order, address to) internal override {
         permit2.permitWitnessTransferFrom(
             order.toPermit(),
             order.transferDetails(to),

--- a/src/reactors/LimitOrderReactor.sol
+++ b/src/reactors/LimitOrderReactor.sol
@@ -15,7 +15,7 @@ contract LimitOrderReactor is BaseReactor {
     constructor(IPermit2 _permit2, address _protocolFeeOwner) BaseReactor(_permit2, _protocolFeeOwner) {}
 
     /// @inheritdoc BaseReactor
-    function resolve(SignedOrder calldata signedOrder)
+    function _resolve(SignedOrder calldata signedOrder)
         internal
         pure
         override
@@ -32,7 +32,7 @@ contract LimitOrderReactor is BaseReactor {
     }
 
     /// @inheritdoc BaseReactor
-    function transferInputTokens(ResolvedOrder memory order, address to) internal override {
+    function _transferInputTokens(ResolvedOrder memory order, address to) internal override {
         permit2.permitWitnessTransferFrom(
             order.toPermit(),
             order.transferDetails(to),

--- a/src/reactors/V2DutchOrderReactor.sol
+++ b/src/reactors/V2DutchOrderReactor.sol
@@ -43,7 +43,7 @@ contract V2DutchOrderReactor is BaseReactor {
     constructor(IPermit2 _permit2, address _protocolFeeOwner) BaseReactor(_permit2, _protocolFeeOwner) {}
 
     /// @inheritdoc BaseReactor
-    function resolve(SignedOrder calldata signedOrder)
+    function _resolve(SignedOrder calldata signedOrder)
         internal
         view
         virtual
@@ -72,7 +72,7 @@ contract V2DutchOrderReactor is BaseReactor {
     }
 
     /// @inheritdoc BaseReactor
-    function transferInputTokens(ResolvedOrder memory order, address to) internal override {
+    function _transferInputTokens(ResolvedOrder memory order, address to) internal override {
         permit2.permitWitnessTransferFrom(
             order.toPermit(),
             order.transferDetails(to),

--- a/test/base/BaseReactor.t.sol
+++ b/test/base/BaseReactor.t.sol
@@ -226,7 +226,7 @@ abstract contract BaseReactorTest is GasSnapshot, ReactorEvents, Test, DeployPer
         ResolvedOrder memory order = ResolvedOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(deadline).withValidationContract(
                 additionalValidationContract
-                ),
+            ),
             input: InputToken(tokenIn, inputAmount, inputAmount),
             outputs: OutputsBuilder.single(address(tokenOut), outputAmount, swapper),
             sig: hex"00",
@@ -274,7 +274,7 @@ abstract contract BaseReactorTest is GasSnapshot, ReactorEvents, Test, DeployPer
         orders[0] = ResolvedOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(block.timestamp + 100).withNonce(
                 0
-                ),
+            ),
             input: InputToken(tokenIn, inputAmount, inputAmount),
             outputs: OutputsBuilder.single(address(tokenOut), outputAmount, swapper),
             sig: hex"00",
@@ -284,7 +284,7 @@ abstract contract BaseReactorTest is GasSnapshot, ReactorEvents, Test, DeployPer
         orders[1] = ResolvedOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(block.timestamp + 100).withNonce(
                 1
-                ),
+            ),
             input: InputToken(tokenIn, 2 * inputAmount, 2 * inputAmount),
             outputs: OutputsBuilder.single(address(tokenOut), 2 * outputAmount, swapper),
             sig: hex"00",
@@ -322,7 +322,7 @@ abstract contract BaseReactorTest is GasSnapshot, ReactorEvents, Test, DeployPer
         orders[0] = ResolvedOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(block.timestamp + 100).withNonce(
                 0
-                ),
+            ),
             input: InputToken(tokenIn, inputAmount, inputAmount),
             outputs: OutputsBuilder.single(NATIVE, outputAmount, swapper),
             sig: hex"00",
@@ -332,7 +332,7 @@ abstract contract BaseReactorTest is GasSnapshot, ReactorEvents, Test, DeployPer
         orders[1] = ResolvedOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(block.timestamp + 100).withNonce(
                 1
-                ),
+            ),
             input: InputToken(tokenIn, 2 * inputAmount, 2 * inputAmount),
             outputs: OutputsBuilder.single(NATIVE, 2 * outputAmount, swapper),
             sig: hex"00",
@@ -374,7 +374,7 @@ abstract contract BaseReactorTest is GasSnapshot, ReactorEvents, Test, DeployPer
         orders[0] = ResolvedOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(block.timestamp + 100).withNonce(
                 0
-                ),
+            ),
             input: InputToken(tokenIn, ONE, ONE),
             outputs: OutputsBuilder.multiple(address(tokenOut), output1, swapper),
             sig: hex"00",
@@ -384,7 +384,7 @@ abstract contract BaseReactorTest is GasSnapshot, ReactorEvents, Test, DeployPer
         orders[1] = ResolvedOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(block.timestamp + 100).withNonce(
                 1
-                ),
+            ),
             input: InputToken(tokenIn, ONE * 2, ONE * 2),
             outputs: OutputsBuilder.multiple(address(tokenOut), output2, swapper),
             sig: hex"00",
@@ -431,7 +431,7 @@ abstract contract BaseReactorTest is GasSnapshot, ReactorEvents, Test, DeployPer
         orders[0] = ResolvedOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(block.timestamp + 100).withNonce(
                 0
-                ),
+            ),
             input: InputToken(tokenIn, ONE, ONE),
             outputs: outputs1,
             sig: hex"00",
@@ -441,7 +441,7 @@ abstract contract BaseReactorTest is GasSnapshot, ReactorEvents, Test, DeployPer
         orders[1] = ResolvedOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(block.timestamp + 100).withNonce(
                 1
-                ),
+            ),
             input: InputToken(tokenIn, ONE * 2, ONE * 2),
             outputs: outputs2,
             sig: hex"00",
@@ -523,7 +523,7 @@ abstract contract BaseReactorTest is GasSnapshot, ReactorEvents, Test, DeployPer
         ResolvedOrder memory order = ResolvedOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(block.timestamp + 100).withNonce(
                 123
-                ),
+            ),
             input: InputToken(tokenIn, inputAmount, inputAmount),
             outputs: OutputsBuilder.single(address(tokenOut), outputAmount, swapper),
             sig: hex"00",
@@ -691,7 +691,7 @@ abstract contract BaseReactorTest is GasSnapshot, ReactorEvents, Test, DeployPer
         ResolvedOrder memory order = ResolvedOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(deadline).withValidationContract(
                 additionalValidationContract
-                ),
+            ),
             input: InputToken(tokenIn, inputAmount, inputAmount),
             outputs: OutputsBuilder.single(address(tokenOut), outputAmount, swapper),
             sig: hex"00",
@@ -733,7 +733,7 @@ abstract contract BaseReactorTest is GasSnapshot, ReactorEvents, Test, DeployPer
         ResolvedOrder memory order = ResolvedOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(deadline).withValidationContract(
                 additionalValidationContract
-                ),
+            ),
             input: InputToken(tokenIn, inputAmount, inputAmount),
             outputs: OutputsBuilder.single(address(tokenOut), outputAmount, swapper),
             sig: hex"00",
@@ -763,7 +763,7 @@ abstract contract BaseReactorTest is GasSnapshot, ReactorEvents, Test, DeployPer
         ResolvedOrder memory order = ResolvedOrder({
             info: OrderInfoBuilder.init(orderReactor).withSwapper(swapper).withDeadline(deadline).withValidationContract(
                 additionalValidationContract
-                ),
+            ),
             input: InputToken(tokenIn, inputAmount, inputAmount),
             outputs: OutputsBuilder.single(address(tokenOut), outputAmount, swapper),
             sig: hex"00",
@@ -787,7 +787,7 @@ abstract contract BaseReactorTest is GasSnapshot, ReactorEvents, Test, DeployPer
         ResolvedOrder memory order = ResolvedOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(deadline).withValidationContract(
                 additionalValidationContract
-                ),
+            ),
             input: InputToken(tokenIn, inputAmount, inputAmount),
             outputs: OutputsBuilder.single(address(tokenOut), outputAmount, swapper),
             sig: hex"00",

--- a/test/executors/SwapRouter02Executor.t.sol
+++ b/test/executors/SwapRouter02Executor.t.sol
@@ -184,7 +184,7 @@ contract SwapRouter02ExecutorTest is Test, PermitSignature, GasSnapshot, DeployP
         DutchOrder memory order2 = DutchOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(block.timestamp + 100).withNonce(
                 1234
-                ),
+            ),
             decayStartTime: block.timestamp - 100,
             decayEndTime: block.timestamp + 100,
             input: DutchInput(tokenIn, ONE, ONE),
@@ -270,7 +270,7 @@ contract SwapRouter02ExecutorTest is Test, PermitSignature, GasSnapshot, DeployP
         DutchOrder memory order2 = DutchOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(block.timestamp + 100).withNonce(
                 1
-                ),
+            ),
             decayStartTime: block.timestamp,
             decayEndTime: block.timestamp + 100,
             input: DutchInput(tokenIn, inputAmount * 3, inputAmount * 3),

--- a/test/reactors/BaseDutchOrderReactor.t.sol
+++ b/test/reactors/BaseDutchOrderReactor.t.sol
@@ -213,7 +213,7 @@ abstract contract BaseDutchOrderReactorTest is PermitSignature, DeployPermit2, B
                 input: DutchInput(tokenIn, 0, 0),
                 outputs: OutputsBuilder.multipleDutch(
                     tokenOut, Solarray.uint256s(1000, 10000, 2000), Solarray.uint256s(900, 9000, 1000), address(0)
-                    )
+                )
             })
         );
         ResolvedOrder memory resolvedOrder = quoter.quote(order.order, order.sig);
@@ -363,7 +363,7 @@ abstract contract BaseDutchOrderReactorTest is PermitSignature, DeployPermit2, B
                 input: DutchInput(tokenIn, 100, 110),
                 outputs: OutputsBuilder.multipleDutch(
                     tokenOut, Solarray.uint256s(1000, 1000), Solarray.uint256s(1000, 900), address(0)
-                    )
+                )
             })
         );
         vm.expectRevert(DutchOrderReactor.InputAndOutputDecay.selector);

--- a/test/reactors/DutchOrderReactor.t.sol
+++ b/test/reactors/DutchOrderReactor.t.sol
@@ -104,7 +104,7 @@ contract DutchOrderReactorTest is PermitSignature, DeployPermit2, BaseDutchOrder
         orders[1] = DutchOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(block.timestamp + 100).withNonce(
                 1
-                ),
+            ),
             decayStartTime: block.timestamp,
             decayEndTime: block.timestamp + 100,
             input: DutchInput(tokenIn, 2 ether, 2 ether),
@@ -166,7 +166,7 @@ contract DutchOrderReactorTest is PermitSignature, DeployPermit2, BaseDutchOrder
         orders[1] = DutchOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(block.timestamp + 100).withNonce(
                 1
-                ),
+            ),
             decayStartTime: block.timestamp,
             decayEndTime: block.timestamp + 100,
             input: DutchInput(tokenIn, inputAmount * 2, inputAmount * 2),
@@ -199,7 +199,7 @@ contract DutchOrderReactorTest is PermitSignature, DeployPermit2, BaseDutchOrder
         orders[1] = DutchOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(block.timestamp + 100).withNonce(
                 1
-                ),
+            ),
             decayStartTime: block.timestamp,
             decayEndTime: block.timestamp + 100,
             input: DutchInput(tokenIn, inputAmount * 2, inputAmount * 2),
@@ -233,7 +233,7 @@ contract DutchOrderReactorTest is PermitSignature, DeployPermit2, BaseDutchOrder
         orders[1] = DutchOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(block.timestamp + 100).withNonce(
                 1
-                ),
+            ),
             decayStartTime: block.timestamp,
             decayEndTime: block.timestamp + 100,
             input: DutchInput(tokenIn, inputAmount, inputAmount),

--- a/test/reactors/ExclusiveDutchOrderReactor.t.sol
+++ b/test/reactors/ExclusiveDutchOrderReactor.t.sol
@@ -211,7 +211,7 @@ contract ExclusiveDutchOrderReactorTest is PermitSignature, DeployPermit2, BaseD
         orders[1] = ExclusiveDutchOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(block.timestamp + 100).withNonce(
                 1
-                ),
+            ),
             decayStartTime: block.timestamp,
             decayEndTime: block.timestamp + 100,
             exclusiveFiller: address(0),
@@ -279,7 +279,7 @@ contract ExclusiveDutchOrderReactorTest is PermitSignature, DeployPermit2, BaseD
         orders[1] = ExclusiveDutchOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(block.timestamp + 100).withNonce(
                 1
-                ),
+            ),
             decayStartTime: block.timestamp,
             decayEndTime: block.timestamp + 100,
             exclusiveFiller: address(0),
@@ -316,7 +316,7 @@ contract ExclusiveDutchOrderReactorTest is PermitSignature, DeployPermit2, BaseD
         orders[1] = ExclusiveDutchOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(block.timestamp + 100).withNonce(
                 1
-                ),
+            ),
             decayStartTime: block.timestamp,
             decayEndTime: block.timestamp + 100,
             exclusiveFiller: address(0),
@@ -354,7 +354,7 @@ contract ExclusiveDutchOrderReactorTest is PermitSignature, DeployPermit2, BaseD
         orders[1] = ExclusiveDutchOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(block.timestamp + 100).withNonce(
                 1
-                ),
+            ),
             decayStartTime: block.timestamp,
             decayEndTime: block.timestamp + 100,
             exclusiveFiller: address(0),

--- a/test/reactors/LimitOrderReactor.t.sol
+++ b/test/reactors/LimitOrderReactor.t.sol
@@ -56,7 +56,7 @@ contract LimitOrderReactorTest is PermitSignature, DeployPermit2, BaseReactorTes
         LimitOrder memory order = LimitOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(address(swapper)).withValidationContract(
                 additionalValidationContract
-                ),
+            ),
             input: InputToken(tokenIn, ONE, ONE),
             outputs: OutputsBuilder.single(address(tokenOut), ONE, address(swapper))
         });
@@ -86,7 +86,7 @@ contract LimitOrderReactorTest is PermitSignature, DeployPermit2, BaseReactorTes
         LimitOrder memory order = LimitOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(address(swapper)).withValidationContract(
                 additionalValidationContract
-                ),
+            ),
             input: InputToken(tokenIn, ONE, ONE),
             outputs: OutputsBuilder.single(address(tokenOut), ONE * 2, address(swapper))
         });
@@ -106,7 +106,7 @@ contract LimitOrderReactorTest is PermitSignature, DeployPermit2, BaseReactorTes
         LimitOrder memory order = LimitOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(address(swapper)).withValidationContract(
                 additionalValidationContract
-                ),
+            ),
             input: InputToken(tokenIn, ONE, ONE),
             outputs: OutputsBuilder.multiple(address(tokenOut), amounts, address(swapper))
         });
@@ -134,7 +134,7 @@ contract LimitOrderReactorTest is PermitSignature, DeployPermit2, BaseReactorTes
         LimitOrder memory order = LimitOrder({
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(address(swapper)).withValidationContract(
                 additionalValidationContract
-                ),
+            ),
             input: InputToken(tokenIn, ONE, ONE),
             outputs: OutputsBuilder.single(address(tokenOut), ONE, address(swapper))
         });

--- a/test/util/mock/MockDutchOrderReactor.sol
+++ b/test/util/mock/MockDutchOrderReactor.sol
@@ -8,10 +8,10 @@ contract MockDutchOrderReactor is DutchOrderReactor {
     constructor(IPermit2 _permit2, address _protocolFeeOwner) DutchOrderReactor(_permit2, _protocolFeeOwner) {}
 
     function resolveOrder(SignedOrder calldata order) external view returns (ResolvedOrder memory resolvedOrder) {
-        return resolve(order);
+        return _resolve(order);
     }
 
-    function resolve(SignedOrder calldata order) internal view override returns (ResolvedOrder memory resolvedOrder) {
-        return DutchOrderReactor.resolve(order);
+    function _resolve(SignedOrder calldata order) internal view override returns (ResolvedOrder memory resolvedOrder) {
+        return DutchOrderReactor._resolve(order);
     }
 }

--- a/test/validation-contracts/ExclusiveFillerValidation.t.sol
+++ b/test/validation-contracts/ExclusiveFillerValidation.t.sol
@@ -55,7 +55,7 @@ contract ExclusiveFillerValidationTest is Test, PermitSignature, GasSnapshot, De
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(block.timestamp + 100)
                 .withValidationContract(exclusiveFillerValidation).withValidationData(
                 abi.encode(address(fillContract), block.timestamp + 50)
-                ),
+            ),
             decayStartTime: block.timestamp,
             decayEndTime: block.timestamp + 100,
             input: DutchInput(tokenIn, inputAmount, inputAmount),
@@ -84,7 +84,7 @@ contract ExclusiveFillerValidationTest is Test, PermitSignature, GasSnapshot, De
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(block.timestamp + 100)
                 .withValidationContract(exclusiveFillerValidation).withValidationData(
                 abi.encode(address(0x1234), block.timestamp + 50)
-                ),
+            ),
             decayStartTime: block.timestamp,
             decayEndTime: block.timestamp + 100,
             input: DutchInput(tokenIn, inputAmount, inputAmount),
@@ -112,7 +112,7 @@ contract ExclusiveFillerValidationTest is Test, PermitSignature, GasSnapshot, De
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(block.timestamp + 100)
                 .withValidationContract(exclusiveFillerValidation).withValidationData(
                 abi.encode(address(0x1234), block.timestamp - 50)
-                ),
+            ),
             decayStartTime: block.timestamp,
             decayEndTime: block.timestamp + 100,
             input: DutchInput(tokenIn, inputAmount, inputAmount),
@@ -137,7 +137,7 @@ contract ExclusiveFillerValidationTest is Test, PermitSignature, GasSnapshot, De
             info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(block.timestamp + 100)
                 .withValidationContract(exclusiveFillerValidation).withValidationData(
                 abi.encode(address(0x1234), block.timestamp)
-                ),
+            ),
             decayStartTime: block.timestamp,
             decayEndTime: block.timestamp + 100,
             input: DutchInput(tokenIn, inputAmount, inputAmount),


### PR DESCRIPTION
internal functions should be prefixed by _

Issue: Cantina #21
