### PR TITLE
feat: standardize rounding in favour of swapper

### DIFF
--- a/src/lib/DutchDecayLib.sol
+++ b/src/lib/DutchDecayLib.sol
@@ -43,7 +43,7 @@ library DutchDecayLib {
                 if (endAmount < startAmount) {
                     decayedAmount = startAmount - (startAmount - endAmount).mulDivDown(elapsed, duration);
                 } else {
-                    decayedAmount = startAmount + (endAmount - startAmount).mulDivDown(elapsed, duration);
+                    decayedAmount = startAmount + (endAmount - startAmount).mulDivUp(elapsed, duration);
                 }
             }
         }

--- a/test/lib/ExclusivityLib.t.sol
+++ b/test/lib/ExclusivityLib.t.sol
@@ -4,16 +4,12 @@ pragma solidity ^0.8.0;
 import {Test} from "forge-std/Test.sol";
 import {MockERC20} from "../util/mock/MockERC20.sol";
 import {OutputsBuilder} from "../util/OutputsBuilder.sol";
-import {FixedPointMathLib} from "solmate/src/utils/FixedPointMathLib.sol";
 import {MockExclusivityLib} from "../util/mock/MockExclusivityLib.sol";
 import {ExclusivityLib} from "../../src/lib/ExclusivityLib.sol";
 import {OrderInfo, ResolvedOrder, OutputToken} from "../../src/base/ReactorStructs.sol";
 import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
 
 contract ExclusivityLibTest is Test {
-    using FixedPointMathLib for uint256;
-    using FixedPointMathLib for uint128;
-
     MockExclusivityLib exclusivity;
     address token1;
     address token2;

--- a/test/lib/ExclusivityLib.t.sol
+++ b/test/lib/ExclusivityLib.t.sol
@@ -4,12 +4,16 @@ pragma solidity ^0.8.0;
 import {Test} from "forge-std/Test.sol";
 import {MockERC20} from "../util/mock/MockERC20.sol";
 import {OutputsBuilder} from "../util/OutputsBuilder.sol";
+import {FixedPointMathLib} from "solmate/src/utils/FixedPointMathLib.sol";
 import {MockExclusivityLib} from "../util/mock/MockExclusivityLib.sol";
 import {ExclusivityLib} from "../../src/lib/ExclusivityLib.sol";
 import {OrderInfo, ResolvedOrder, OutputToken} from "../../src/base/ReactorStructs.sol";
 import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
 
 contract ExclusivityLibTest is Test {
+    using FixedPointMathLib for uint256;
+    using FixedPointMathLib for uint128;
+
     MockExclusivityLib exclusivity;
     address token1;
     address token2;


### PR DESCRIPTION
This commit changes decay to standardize rounding in favour of swapper
- rounding output amounts up and input amounts down
