### PR TITLE
fix: invalidCosignature already defined in CosignerLib

### DIFF
--- a/src/reactors/V3DutchOrderReactor.sol
+++ b/src/reactors/V3DutchOrderReactor.sol
@@ -34,9 +34,6 @@ contract V3DutchOrderReactor is BaseReactor {
     /// @notice thrown when an order's deadline is passed
     error DeadlineReached();
 
-    /// @notice thrown when an order's cosignature does not match the expected cosigner
-    error InvalidCosignature();
-
     /// @notice thrown when an order's cosigner input is greater than the specified
     error InvalidCosignerInput();
 

--- a/test/reactors/V3DutchOrderReactor.t.sol
+++ b/test/reactors/V3DutchOrderReactor.t.sol
@@ -30,6 +30,7 @@ import {CurveBuilder} from "../util/CurveBuilder.sol";
 import {OrderQuoter} from "../../src/lens/OrderQuoter.sol";
 import {Solarray} from "solarray/Solarray.sol";
 import {MathExt} from "../../src/lib/MathExt.sol";
+import {CosignerLib} from "../../src/lib/CosignerLib.sol";
 
 contract V3DutchOrderTest is PermitSignature, DeployPermit2, BaseReactorTest {
     using OrderInfoBuilder for OrderInfo;
@@ -431,7 +432,7 @@ contract V3DutchOrderTest is PermitSignature, DeployPermit2, BaseReactorTest {
         order.cosignature = cosignOrder(order.hash(), cosignerData);
         SignedOrder memory signedOrder =
             SignedOrder(abi.encode(order), signOrder(swapperPrivateKey, address(permit2), order));
-        vm.expectRevert(V3DutchOrderReactor.InvalidCosignature.selector);
+        vm.expectRevert(CosignerLib.InvalidCosignature.selector);
         fillContract.execute(signedOrder);
     }
 
@@ -459,7 +460,7 @@ contract V3DutchOrderTest is PermitSignature, DeployPermit2, BaseReactorTest {
         order.cosignature = bytes.concat(keccak256("invalidSignature"), keccak256("invalidSignature"), hex"33");
         SignedOrder memory signedOrder =
             SignedOrder(abi.encode(order), signOrder(swapperPrivateKey, address(permit2), order));
-        vm.expectRevert(V3DutchOrderReactor.InvalidCosignature.selector);
+        vm.expectRevert(CosignerLib.InvalidCosignature.selector);
         fillContract.execute(signedOrder);
     }
 


### PR DESCRIPTION
`invalidCosignature()` is never used as a revert in `V3DutchOrderReactor.sol`. It is already declared in `CosignerLib` where the revert based on cosignature occurs.