### PR TITLE
audit(1): Missing min < max check

### DIFF
--- a/src/lib/MathExt.sol
+++ b/src/lib/MathExt.sol
@@ -34,6 +34,7 @@ library MathExt {
     /// @param max The maximum bound for the result.
     /// @return r The result of the bounded subtraction.
     function boundedSub(uint256 a, int256 b, uint256 min, uint256 max) internal pure returns (uint256 r) {
+        require(min <= max, "MathExt: min must be less than or equal to max");
         if (b < 0) {
             // If b is negative, add its absolute value to a
             uint256 absB = uint256(-b);

--- a/test/lib/MathExt.t.sol
+++ b/test/lib/MathExt.t.sol
@@ -45,7 +45,7 @@ contract MathExtTest is Test {
 
     function testBoundedSub(uint128 a, int128 b, uint256 max, uint256 min) public {
         vm.assume(max >= min);
-        uint256 c = uint256(a).boundedSub(b, max, min);
+        uint256 c = uint256(a).boundedSub(b, min, max);
         assertGe(c, min);
         assertLe(c, max);
     }
@@ -69,6 +69,13 @@ contract MathExtTest is Test {
 
     function testBoundedSubIntFromUintOverflow() public {
         assertEq(UINT256_MAX.boundedSub(-1, 0, type(uint256).max), type(uint256).max);
+    }
+
+    function testBoundedSubRequiresMinLessThanMax() public {
+        uint256 a = 3;
+        int256 b = 2;
+        vm.expectRevert();
+        a.boundedSub(b, 2, 0);
     }
 
     /* sub(uint256 a, uint256 b) tests */


### PR DESCRIPTION
Require that `boundedSub` follows the invariant of: `min <= max`