### PR TITLE
audit(20): Fix typo in comments

### DIFF
--- a/src/lib/V3DutchOrderLib.sol
+++ b/src/lib/V3DutchOrderLib.sol
@@ -210,7 +210,7 @@ library V3DutchOrderLib {
     }
 
     /// @notice get the digest of the cosigner data
-    /// @param order the priorityOrder
+    /// @param order the V3DutchOrder
     /// @param orderHash the hash of the order
     function cosignerDigest(V3DutchOrder memory order, bytes32 orderHash) internal pure returns (bytes32) {
         return keccak256(abi.encodePacked(orderHash, abi.encode(order.cosignerData)));


### PR DESCRIPTION
Parameter comment mentions `PriorityOrder` instead of `V3DutchOrder`