### PR TITLE
docs: update UniswapX deployment addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,22 +44,47 @@ Jump to the docs for [Creating a Filler Integration](https://docs.uniswap.org/co
 
 # Deployment Addresses
 
-## Ethereum Mainnet
+## Ethereum Mainnet 
+
 
 | Contract                      | Address                                                                                                               | Source                                                                                                                    |
-| ---                           | ---                                                                                                                   | ---                                                                                                                       |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | V2 Dutch Order Reactor        | [0x00000011F84B9aa48e5f8aA8B9897600006289Be](https://etherscan.io/address/0x00000011F84B9aa48e5f8aA8B9897600006289Be) | [V2DutchOrderReactor](https://github.com/Uniswap/UniswapX/blob/v2.0.0/src/reactors/V2DutchOrderReactor.sol)               |
 | Exclusive Dutch Order Reactor | [0x6000da47483062A0D734Ba3dc7576Ce6A0B645C4](https://etherscan.io/address/0x6000da47483062A0D734Ba3dc7576Ce6A0B645C4) | [ExclusiveDutchOrderReactor](https://github.com/Uniswap/UniswapX/blob/v1.1.0/src/reactors/ExclusiveDutchOrderReactor.sol) |
 | OrderQuoter                   | [0x54539967a06Fc0E3C3ED0ee320Eb67362D13C5fF](https://etherscan.io/address/0x54539967a06Fc0E3C3ED0ee320Eb67362D13C5fF) | [OrderQuoter](https://github.com/Uniswap/UniswapX/blob/v1.1.0/src/lens/OrderQuoter.sol)                                   |
 | Permit2                       | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://etherscan.io/address/0x000000000022D473030F116dDEE9F6B43aC78BA3) | [Permit2](https://github.com/Uniswap/permit2)                                                                             |
 
+
+## Arbitrum
+
+
+| Contract                           | Address                                                                                                              | Source                                                                                                    |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| DutchV3 Order Reactor              | [0xB274d5F4b833b61B340b654d600A864fB604a87c](https://arbiscan.io/address/0xB274d5F4b833b61B340b654d600A864fB604a87c) | [V3DutchOrderReactor](https://github.com/Uniswap/UniswapX/blob/main/src/reactors/V3DutchOrderReactor.sol) |
+| DutchV2 Order Reactor (deprecated) | [0x1bd1aAdc9E230626C44a139d7E70d842749351eb](https://arbiscan.io/address/0x1bd1aAdc9E230626C44a139d7E70d842749351eb) | [V2DutchOrderReactor](https://github.com/Uniswap/UniswapX/blob/main/src/reactors/V2DutchOrderReactor.sol) |
+| OrderQuoter                        | [0x88440407634F89873c5D9439987Ac4BE9725fea8](https://arbiscan.io/address/0x88440407634F89873c5D9439987Ac4BE9725fea8) | [OrderQuoter](https://github.com/Uniswap/UniswapX/blob/v1.1.0/src/lens/OrderQuoter.sol)                   |
+| Permit2                            | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://arbiscan.io/address/0x000000000022D473030F116dDEE9F6B43aC78BA3) | [Permit2](https://github.com/Uniswap/permit2)                                                             |
+
+
 ## Base
 
-| Contract                      | Address                                                                                                               | Source                                                                                                                    |
-| ---                           | ---                                                                                                                   | ---                                                                                                                       |
-| Priority Order Reactor        | [0x000000001Ec5656dcdB24D90DFa42742738De729](https://basescan.org/address/0x000000001Ec5656dcdB24D90DFa42742738De729) | [PriorityOrderReactor](https://github.com/Uniswap/UniswapX/blob/v2.1.0/src/reactors/PriorityOrderReactor.sol)             |
-| OrderQuoter                   | [0x88440407634f89873c5d9439987ac4be9725fea8](https://basescan.io/address/0x88440407634f89873c5d9439987ac4be9725fea8)  | [OrderQuoter](https://github.com/Uniswap/UniswapX/blob/v2.1.0/src/lens/OrderQuoter.sol)                                   |
-| Permit2                       | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://basescan.io/address/0x000000000022D473030F116dDEE9F6B43aC78BA3)  | [Permit2](https://github.com/Uniswap/permit2)                                                                             |
+
+| Contract               | Address                                                                                                               | Source                                                                                                        |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Priority Order Reactor | [0x000000001Ec5656dcdB24D90DFa42742738De729](https://basescan.org/address/0x000000001Ec5656dcdB24D90DFa42742738De729) | [PriorityOrderReactor](https://github.com/Uniswap/UniswapX/blob/v2.1.0/src/reactors/PriorityOrderReactor.sol) |
+| OrderQuoter            | [0x88440407634f89873c5d9439987ac4be9725fea8](https://basescan.org/address/0x88440407634f89873c5d9439987ac4be9725fea8) | [OrderQuoter](https://github.com/Uniswap/UniswapX/blob/v2.1.0/src/lens/OrderQuoter.sol)                       |
+| Permit2                | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://basescan.org/address/0x000000000022D473030F116dDEE9F6B43aC78BA3) | [Permit2](https://github.com/Uniswap/permit2)                                                                 |
+
+
+## Unichain
+
+
+| Contract               | Address                                                                                                              | Source                                                                                                      |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Priority Order Reactor | [0x00000006021a6Bce796be7ba509BBBA71e956e37](https://uniscan.xyz/address/0x00000006021a6Bce796be7ba509BBBA71e956e37) | [PriorityOrderReactor](https://github.com/Uniswap/UniswapX/blob/main/src/reactors/PriorityOrderReactor.sol) |
+| OrderQuoter            | [0x88440407634F89873c5D9439987Ac4BE9725fea8](https://uniscan.xyz/address/0x88440407634F89873c5D9439987Ac4BE9725fea8) | [OrderQuoter](https://github.com/Uniswap/UniswapX/blob/v1.1.0/src/lens/OrderQuoter.sol)                     |
+| Permit2                | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://uniscan.xyz/address/0x000000000022D473030F116dDEE9F6B43aC78BA3) | [Permit2](https://github.com/Uniswap/permit2)                                                               |
+
 
 # Usage
 


### PR DESCRIPTION
**Issue**
[#322](https://github.com/Uniswap/UniswapX/issues/322)

**Summary**

- Update `README.md` deployment section to reflect all current UniswapX deployments.
- Add missing Arbitrum and Unichain sections alongside existing Mainnet and Base sections.
- Align addresses and source links with the official docs and SDK mappings.

**Details**

- Confirmed Mainnet Dutch reactors and `OrderQuoter` addresses unchanged and still correct.
- Added Arbitrum deployments for Dutch V3, deprecated Dutch V2, shared `OrderQuoter`, and `Permit2`.
- Added Unichain deployments for `PriorityOrderReactor`, shared `OrderQuoter`, and `Permit2`.
- Normalized Basescan URLs in the Base section to be consistent.
