### PR TITLE
feat: deploy DutchV3 reactor + OrderQuoter to Robinhood (4663) and Arc (5042)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,39 @@ Jump to the docs for [Creating a Filler Integration](https://docs.uniswap.org/co
 | OrderQuoter                   | [0x00000000a3db63Df9078cBF3dF88B4CAdD5a7F58](https://explorer.zora.energy/address/0x00000000a3db63Df9078cBF3dF88B4CAdD5a7F58) | [OrderQuoter](./src/lens/OrderQuoter.sol)                     |
 | Permit2                       | [0x000000000022D473030F116dDEE9F6B43aC78BA3](https://explorer.zora.energy/address/0x000000000022D473030F116dDEE9F6B43aC78BA3) | [Permit2](https://github.com/Uniswap/permit2)                 |
 
+## Robinhood (DutchV3)
+
+| Contract                      | Address                                      | Source                                                        |
+| ---                           | ---                                          | ---                                                           |
+| V3 Dutch Order Reactor        | 0x000000007A1C8e570011EeDF86A2A35593013cBA   | [V3DutchOrderReactor](./src/reactors/V3DutchOrderReactor.sol) |
+| OrderQuoter                   | 0x00000000a3db63Df9078cBF3dF88B4CAdD5a7F58   | [OrderQuoter](./src/lens/OrderQuoter.sol)                     |
+| Permit2                       | 0x000000000022D473030F116dDEE9F6B43aC78BA3   | [Permit2](https://github.com/Uniswap/permit2)                 |
+
+Robinhood Chain (chainId 4663) is an Arbitrum Orbit L2, so `block.number`
+returns the parent-chain (Ethereum) block estimate. The reactor's
+[`BlockNumberish`](./src/base/BlockNumberish.sol) routes chainId 4663 through
+`ArbSys(0x64).arbBlockNumber()` — the same path as Arbitrum One — so V3 decay
+ticks on L2 block height. Explorer links pending the mainnet explorer URL;
+see [playbook/chains/robinhood.md](./playbook/chains/robinhood.md).
+
+## Arc (DutchV3)
+
+| Contract                      | Address                                      | Source                                                        |
+| ---                           | ---                                          | ---                                                           |
+| V3 Dutch Order Reactor        | 0x0000000015134054eA82AE0bb9fda66b36402C36   | [V3DutchOrderReactor](./src/reactors/V3DutchOrderReactor.sol) |
+| OrderQuoter                   | 0x00000000a3db63Df9078cBF3dF88B4CAdD5a7F58   | [OrderQuoter](./src/lens/OrderQuoter.sol)                     |
+| Permit2                       | 0x000000000022D473030F116dDEE9F6B43aC78BA3   | [Permit2](https://github.com/Uniswap/permit2)                 |
+
+Arc (chainId 5042) is Circle's stablecoin-native L1: USDC is the gas token,
+exposed natively at 18 decimals and as a 6-decimal ERC-20 predeploy at
+`0x3600000000000000000000000000000000000000` over the same balance. Orders
+must use the ERC-20 address (the API rejects the `0x0` native sentinel —
+there is no wrapped token, and mixing the two representations is a silent
+1e12 decimals error). `block.basefee` is constant (20 gwei in native-USDC
+wei), so `adjustmentPerGweiBaseFee` is set to 0 at order construction.
+Explorer links pending Arcscan mainnet; see
+[playbook/chains/arc.md](./playbook/chains/arc.md).
+
 # Usage
 
 ```

--- a/deployments.md
+++ b/deployments.md
@@ -21,6 +21,14 @@ Deployed by `0x2179a60856E37dfeAacA0ab043B931fE224b27B6` on **2026-05-07**
 that ran into a mainnet gas-limit issue, and Tempo's pre-existing OrderQuoter
 from ECO-365 phase 1b).
 
+**Robinhood (4663) + Arc (5042)** deployed by
+`0xA53247dEeC5884B5A10667dee1C378e729a93e03` on **2026-06-12**. Robinhood's
+reactor is built from post-`BlockNumberish`-4663 bytecode (Robinhood is an
+Arbitrum Orbit chain; decay reads `ArbSys.arbBlockNumber()`), so its
+creationCode — and therefore any future chain's mined salt — differs from the
+17 chains deployed before that change. Arc's reactor was mined and deployed
+against the pre-change bytecode. See `playbook/chains/{robinhood,arc}.md`.
+
 ## OrderQuoter address
 
 Same address on every chain: **`0x00000000a3db63Df9078cBF3dF88B4CAdD5a7F58`**.
@@ -37,6 +45,8 @@ Same address on every chain: **`0x00000000a3db63Df9078cBF3dF88B4CAdD5a7F58`**.
 | Worldchain | 480 | ✅ deployed | ✅ Etherscan |
 | Soneium | 1868 | ✅ deployed | ✅ Sourcify (Blockscout) |
 | Tempo | 4217 | ✅ pre-existing (ECO-365 phase 1b) | ✅ Sourcify |
+| Robinhood | 4663 | ✅ deployed 2026-06-12 | ❌ (mainnet explorer URL not yet published) |
+| Arc | 5042 | ✅ deployed 2026-06-12 | ❌ (Arcscan mainnet verifier not yet confirmed) |
 | Base | 8453 | ✅ deployed (recovered after a transient Cloudflare 502) | ✅ Etherscan |
 | Arbitrum | 42161 | ✅ deployed | ✅ Etherscan |
 | Celo | 42220 | ✅ deployed | ✅ Etherscan |
@@ -59,6 +69,8 @@ Same address on every chain: **`0x00000000a3db63Df9078cBF3dF88B4CAdD5a7F58`**.
 | Worldchain | 480 | [`0x00000000d714EA34028930b762E96bFBe50F42C2`](https://worldscan.org/address/0x00000000d714EA34028930b762E96bFBe50F42C2) | `0xcb2436774C3e191c85056d248EF4260ce5f27A9D` | ✅ |
 | Soneium | 1868 | [`0x000000005aF66799D1a6317714D66800f9CA1406`](https://soneium.blockscout.com/address/0x000000005aF66799D1a6317714D66800f9CA1406) | `0x2bad8182c09f50c8318d769245bea52c32be46cd` | ✅ |
 | Tempo | 4217 | [`0x00000000fc1E66C9f582566EAd00108e55F1c0C6`](https://explorer.tempo.xyz/address/0x00000000fc1E66C9f582566EAd00108e55F1c0C6) | `0xCFB43dC56B55bE9611deD8384201cECf06A9811b` | 🟡 Sourcify (explorer ingest unconfirmed) |
+| Robinhood | 4663 | `0x000000007A1C8e570011EeDF86A2A35593013cBA` | `0x2bad8182c09f50c8318d769245bea52c32be46cd` | ❌ (explorer TBD) |
+| Arc | 5042 | `0x0000000015134054eA82AE0bb9fda66b36402C36` | `0x33f26c5d69e2c40956f22c6195b6a499cf4151e8` | ❌ (explorer TBD) |
 | Base | 8453 | [`0x000000008a8330B5d1F43A62Bf4C673A49f27ba0`](https://basescan.org/address/0x000000008a8330B5d1F43A62Bf4C673A49f27ba0) | `0x31FAfd4889FA1269F7a13A66eE0fB458f27D72A9` | ✅ |
 | Arbitrum | 42161 | [`0xB274d5F4b833b61B340b654d600A864fB604a87c`](https://arbiscan.io/address/0xB274d5F4b833b61B340b654d600A864fB604a87c) | (see uniswapx-sdk) | ✅ (pre-existing) |
 | Celo | 42220 | [`0x00000000B8077fdf2281A80bE96f6c282B5d943A`](https://celoscan.io/address/0x00000000B8077fdf2281A80bE96f6c282B5d943A) | `0x0Eb863541278308c3A64F8E908BC646e27BFD071` | ✅ |
@@ -90,6 +102,8 @@ chains.
 | Worldchain | 480 | `0x540948dcd8e6b2dca528a1f562aafa579199ba6ee0ce0a8001cb0e05950117f4` |
 | Soneium | 1868 | `0xcb5a9516b309b1ab2e12992058f2480b4773bbf5f851ea689331ab25c13b6dce` |
 | Tempo | 4217 | `0x5e97c535dc39893f883c8c96ba29f49a7a911d6fd2c584c3b3e02ece1cedb92d` |
+| Robinhood | 4663 | `0xc9abd2162ed894365b5190cb55048bbb9e29b4d1fd448eef999d7e66f34e4e6b` (quoter: `0xe9ebd4c203f899a57dce7b87f10e2a4f94a94489736747462e43de52b4cd24fc`) |
+| Arc | 5042 | `0x9362b52b9b93f7b01e680d43d6f6c7355b0f832148617abfbbcd3a029409c096` (quoter: `0xd2c470b6df102890d28820bb34d0c48d7499a1a3d1df4921da2fb79842140646`) |
 | Base | 8453 | `0xef1b4c1893bba99de9f5f56d1e2f0c9850424ecea2875ae16e95598ce9ab5d09` |
 | Celo | 42220 | `0x02f1c4477908154ab7eac35d95757b57ba9ec04ec944b54c58667f03baf3b760` |
 | Avalanche | 43114 | `0x1ee85f6ea0dc5b7c83f7e7a3d107391022dd1aee0f0fad8483f2b64a1c970afe` |

--- a/deployments.md
+++ b/deployments.md
@@ -112,9 +112,10 @@ chains.
 
 ## Integration test results
 
-All 16 reactor instances were exercised with the V3 Dutch order integration
+All 18 reactor instances were exercised with the V3 Dutch order integration
 suite (`test/integration/V3DutchOrderIntegration.t.sol`) against their
-respective chain's public RPC, fork pinned to current-block-minus-50:
+respective chain's public RPC, fork pinned to current-block-minus-50
+(Robinhood + Arc added 2026-06-23):
 
 ```
 FOUNDRY_RPC_URL=<chain rpc>
@@ -134,10 +135,11 @@ local EVM). The `OrderQuoter` lens is the real on-chain instance at
 quoter deploy made the fork-deploy fallback that earlier versions of the
 test had unnecessary.
 
-Arbitrum requires a `vm.mockCall` on the ArbSys precompile (`0x64`) since
-the reactor's `BlockNumberish` mixin captures chainid 42161 at deploy time
-and routes block-number reads through ArbSys, which Foundry's local EVM
-doesn't implement.
+Arbitrum One and Robinhood require a `vm.mockCall` on the ArbSys precompile
+(`0x64`) since the reactor's `BlockNumberish` mixin captures the chainid at
+deploy time and routes block-number reads through ArbSys on those chains
+(42161 and 4663 — both Arbitrum Orbit), which Foundry's local EVM doesn't
+implement.
 
 | Chain | ID | Reactor | Tests |
 |---|---|---|---|
@@ -151,6 +153,8 @@ doesn't implement.
 | Worldchain | 480 | `0x00000000d714EA34028930b762E96bFBe50F42C2` | ✅ 6/6 |
 | Soneium | 1868 | `0x000000005aF66799D1a6317714D66800f9CA1406` | ✅ 6/6 |
 | Tempo | 4217 | `0x00000000fc1E66C9f582566EAd00108e55F1c0C6` | ✅ 6/6 |
+| Robinhood | 4663 | `0x000000007A1C8e570011EeDF86A2A35593013cBA` | ✅ 6/6 |
+| Arc | 5042 | `0x0000000015134054eA82AE0bb9fda66b36402C36` | ✅ 6/6 |
 | Base | 8453 | `0x000000008a8330B5d1F43A62Bf4C673A49f27ba0` | ✅ 6/6 |
 | Arbitrum | 42161 | `0xB274d5F4b833b61B340b654d600A864fB604a87c` | ✅ 6/6 |
 | Celo | 42220 | `0x00000000B8077fdf2281A80bE96f6c282B5d943A` | ✅ 6/6 |

--- a/playbook/chains/README.md
+++ b/playbook/chains/README.md
@@ -23,6 +23,8 @@ only.
 | Worldchain | 480 | ⏳ research | [worldchain.md](./worldchain.md) |
 | Soneium | 1868 | ⏳ research | [soneium.md](./soneium.md) |
 | Tempo | 4217 | ✅ DutchV3 live (ECO-365) | (see [../NEW_CHAIN.md §6](../NEW_CHAIN.md)) |
+| Robinhood | 4663 | 🟢 reactor + quoter deployed 2026-06-12 (post-`BlockNumberish`-4663 bytecode); service wiring pending | [robinhood.md](./robinhood.md) |
+| Arc | 5042 | 🟢 reactor + quoter deployed 2026-06-12; service wiring pending | [arc.md](./arc.md) |
 | Base | 8453 | ⏳ research | [base.md](./base.md) |
 | Arbitrum | 42161 | ✅ DutchV3 live (Arbitrum was the first V3 chain) | (skip) |
 | Celo | 42220 | ⏳ research | [celo.md](./celo.md) |

--- a/playbook/chains/arc.md
+++ b/playbook/chains/arc.md
@@ -1,0 +1,100 @@
+# Arc (chainId 5042)
+
+Status: 🟢 **Contracts deployed 2026-06-12** — `V3DutchOrderReactor` at `0x0000000015134054eA82AE0bb9fda66b36402C36` (owner + permit2 verified on-chain), `OrderQuoter` at canonical `0x00000000a3db63Df9078cBF3dF88B4CAdD5a7F58`. Explorer verification + SDK/service wiring (Phases 2–4) pending. Config caveats below still apply to the service rollout.
+
+Original audit assessment: 🟡 Has caveats, but mechanically ready — no contract-code changes needed. Circle's stablecoin-native L1 (reth `v1.11.3` execution, Malachite BFT consensus). Permit2 + Arachnid CREATE2 deployer present and functional. Caveats are all config-side, and all have Tempo/Celo precedent:
+
+1. **USDC is the native gas token** with dual representation: 18-decimal native (`eth_getBalance`/`msg.value`) and a 6-decimal ERC-20 interface predeploy at `0x3600000000000000000000000000000000000000` over the *same balance* (verified live: same account shows `9355344270750000000` native and `9355344` via `balanceOf`). Celo-style, not Tempo-style — `CALLVALUE`/`BALANCE` work normally.
+2. **Constant basefee** (20 gwei, unchanged across 1M+ blocks ≈ 5.8 days) → `adjustmentPerGweiBaseFee = 0`, `GAS_COMPARISON_MULTIPLIER = 0`.
+3. **Sub-second blocks** (~500ms) → Tempo-style `MIN_RETRY_WAIT` floor + `V3_BLOCK_BUFFER = 1`.
+
+v4 **is** deployed (PoolManager `0x8366a39cc670b4001a1121b8f6a443a643e40951`, per sdk-core `ARC_ADDRESSES`); `PoolManager.owner()` returns `0x33f26c5d69e2c40956f22c6195b6a499cf4151e8` (verified live 2026-06-12; a 171-byte proxy on Arc, likely a Safe). That is **not** the canonical owner, so the canonical Tempo salt does **not** apply — **Arc needs its own `(salt, expectedReactor)` pair mined** via `./scripts/mine-salt.sh 5042`, after the Robinhood `BlockNumberish.sol` change lands so both chains share one bytecode state.
+
+Source: live RPC probes against the QuikNode endpoint (2026-06-12) + [docs.arc.io](https://docs.arc.io) (docs still testnet-focused; predeploys verified directly on mainnet).
+
+---
+
+## §0 Pre-integration questionnaire
+
+| Question | Answer |
+|---|---|
+| **chainId** | `5042` (`0x13b2`) — mainnet. (Testnet is `5042002`.) |
+| **RPC + explorer URLs** | Probed via QuikNode: `https://cool-compatible-friday.arc-mainnet.quiknode.pro/<key>/`. Explorer: Arcscan (testnet at `testnet.arcscan.app`; mainnet URL to confirm — `explorer.arc.io` responds with a redirect). |
+| **Block time (target)** | ~500ms steady (observed 20 consecutive blocks over 10s, 2 blocks/s, including empty blocks — continuous production, not on-demand). |
+| **Finality model** | Malachite BFT — deterministic sub-second finality (per Circle docs). Treat 1 confirmation as final; no reorgs in normal operation. |
+| **`block.number` semantics** | Standard EVM monotonic counter (reth; height ~4.83M). No `BlockNumberish.sol` branch needed. |
+| **`block.basefee` semantics** | **Constant `20000000000` (20 gwei)** — flat across samples spanning 1M blocks. Denominated in native-USDC wei (1e-18 USDC), so gas costs 2e-8 USDC/gas — numerically identical to Tempo's `2e10` attodollars. `eth_maxPriorityFeePerGas` suggests 5 gwei, so tips exist, but basefee itself doesn't move → zero the gas-adjustment levers (see deploy params). |
+| **`block.timestamp` semantics** | Standard Unix seconds. |
+| **Native gas token** | **USDC** — native asset at 18-decimal precision; canonical 6-decimal ERC-20 interface predeploy at `0x3600000000000000000000000000000000000000` (symbol `USDC`, `decimals() = 6`, standard `allowance`/`totalSupply` verified). Same balance, two precisions — **never mix the representations** (12-decimal scale factor). No wrapped-USDC contract exists (none needed). |
+| **`CALLVALUE` / `BALANCE` / `SELFBALANCE` opcodes** | Standard — native USDC flows through `payable` paths (unlike Tempo). Reactor's `NATIVE` sentinel would *work* mechanically, but reject it at the API boundary anyway (see Notes). |
+| **State creation costs** | Standard reth gas schedule; at the constant 20 gwei USDC-wei basefee, a 250K-gas cold fill costs ~$0.005. Immaterial (Correction F). |
+| **Permit2 at canonical address?** | ✅ Yes — 9,152 bytes at `0x000000000022D473030F116dDEE9F6B43aC78BA3`, `DOMAIN_SEPARATOR()` non-zero (`0xa88a...b18f`). Listed as an official Arc predeploy in Circle's docs. |
+| **Sequencer / private mempool / pre-confs** | Permissioned Malachite validator set operated by Circle + partners. No public-mempool MEV in the Ethereum sense; RFQ exclusivity via reactor `ExclusivityLib` as usual. |
+| **EIP-1559 / typed tx support** | ✅ Type-2 txs; `baseFeePerGas` populated (constant), `eth_maxPriorityFeePerGas` live. Cosigner tripwire on `startingBaseFee` is trivially stable. |
+| **Routing surfaces (UniversalRouter, etc.)** | Uniswap v3 + v4 deployed per sdk-core `ARC_ADDRESSES`: v4 PoolManager `0x8366a39cc670b4001a1121b8f6a443a643e40951` (24KB code verified live), v3 factory `0xf0db...3918`, SwapRouter02 `0x53bf...6f77`, v4 Quoter `0x8dc1...8f94`. Multicall3 ✅ at canonical `0xcA11...CA11`. Classic-route quote source exists. |
+| **protocolFeeOwner** | `0x33f26c5d69e2c40956f22c6195b6a499cf4151e8` — derived from `PoolManager.owner()` (verified live 2026-06-12). Contract on Arc (171-byte proxy, likely Safe) — passes the expected-multisig sanity check. |
+
+---
+
+## §1 EVM compatibility audit
+
+| Behavior | Standard? | Notes for Arc |
+|---|---|---|
+| `block.number` monotonic & contiguous | ✅ | Standard reth counter. |
+| `block.basefee` real wei value | ⚠️ **Constant** | Real field, but pinned at 20 gwei (USDC-wei). Set `adjustmentPerGweiBaseFee = 0` in `DutchV3OrderFactory` for 5042 (Correction B: factory-side, swapper-signed payload). |
+| `block.timestamp` seconds since epoch, monotonic | ✅ | Standard. |
+| `msg.value` reflects sent native | ✅ | Native = USDC at 18 decimals. `payable` paths work (unlike Tempo). |
+| `address(this).balance` reflects native balance | ✅ | Sample-executor native sweeps mechanically work, but sweep *USDC*, not ETH — semantics differ from what executor integrators expect; prefer ERC-20-only flows. |
+| Permit2 deployed at canonical address | ✅ | Verified + functional. **Permit2 works against the 6-decimal ERC-20 interface** (standard `allowance`/`transferFrom` surface). |
+| Arachnid CREATE2 deployer present | ✅ | 69 bytes at canonical address (official Arc predeploy). |
+| EIP-1559 fields populated | ✅ | Populated; basefee constant. |
+| Reactor address availability | ✅ | Fresh salt will be mined for owner `0x33f2...51e8`; CREATE2 derivation guarantees a virgin address. |
+
+Non-standard cells → add an "Arc deployment notes" section to `README.md` post-deploy (constant basefee, USDC-native dual decimals, native-sentinel API rejection), mirroring the Tempo block.
+
+---
+
+## Existing UniswapX coverage (uniswapx-sdk `src/constants.ts`)
+
+All four maps need new `5042` entries after deploy:
+
+- `PERMIT2_MAPPING[5042]` → `0x000000000022d473030f116ddee9f6b43ac78ba3`
+- `REACTOR_ADDRESS_MAPPING[5042]` → `{ [OrderType.Dutch_V3]: 0x0000000015134054eA82AE0bb9fda66b36402C36 }` (deployed 2026-06-12)
+- `UNISWAPX_ORDER_QUOTER_MAPPING[5042]` → `0x00000000a3db63Df9078cBF3dF88B4CAdD5a7F58` (uniform canonical quoter — OrderQuoter initcode is owner-independent, so its canonical address still applies)
+- `EXCLUSIVE_FILLER_VALIDATION_MAPPING[5042]` → zero address (reactor-enforced exclusivity)
+
+`@uniswap/sdk-core` is a no-op: `ChainId.ARC = 5042` is already shipped with the full v3/v4 `ARC_ADDRESSES` block (and correctly no `WETH9` entry — Correction E territory). Phase 1 reduces to the x-contracts deploy.
+
+---
+
+## Deploy parameters
+
+| Parameter | Value | Rationale |
+|---|---|---|
+| `FOUNDRY_REACTOR_OWNER` | `0x33f26c5d69e2c40956f22c6195b6a499cf4151e8` | Derived from `PoolManager.owner()` at `0x8366a39cc670b4001a1121b8f6a443a643e40951` (proxy/Safe on Arc). |
+| `V3_REACTOR_SALT` / `V3_REACTOR_EXPECTED` | `0x...179cec38645d390d013a0040` / `0x0000000015134054eA82AE0bb9fda66b36402C36` — **mined + deployed 2026-06-12** | Owner is not canonical → Tempo salt did not apply; fresh pair mined (4 leading + 4 total zero bytes). |
+| Deploy route (as executed) | Direct single-chain `forge script script/DeployDutchV3.s.sol` invocation from macOS, deployer `0xA53247dEeC5884B5A10667dee1C378e729a93e03`, ~0.22 native USDC gas | Deployed **before** the Robinhood `BlockNumberish.sol` 4663 branch (Arc-first ordering) — this reactor runs pre-change bytecode, which is equivalent on Arc (standard `block.number`). |
+| Lens | OrderQuoter at canonical `0x00000000a3db63Df9078cBF3dF88B4CAdD5a7F58` via `script/DeployOrderQuoter.s.sol` | Chain-independent initcode. |
+| Deployer gas funding | **Native USDC on Arc** (CCTP domain 26) | `MIN_BALANCE_WEI = 5e16` ≈ 0.05 native USDC — i.e. five cents. Whole deploy costs well under $1. |
+| `BLOCK_TIME_MS_BY_CHAIN[5042]` (x-service) | `500` | Observed 2 blocks/s. |
+| `AVERAGE_BLOCK_TIME(5042)` (x-service) | `1` (or fractional if supported — mirror Tempo's entry) | 500ms real. |
+| `MIN_RETRY_WAIT_SECONDS_ARC` floor (x-service) | `2` | Correction D — sub-second blocks; chain-scoped, mirror Tempo. |
+| `V3_BLOCK_LENGTH_BY_CHAIN[5042]` (trading-api) | `60` | `ceil(30 / 0.5)` — Tempo parity. |
+| `V3_BLOCK_BUFFER` (parameterization-api) | `1` | Fast blocks — Tempo parity. |
+| `getBlockTimeSecs(5042)` (parameterization-api) | `0.5` | — |
+| `GAS_COMPARISON_MULTIPLIER_BY_CHAIN[5042]` | `0` | Gas is constant sub-cent USDC; RFQ-vs-Classic gas comparison is noise. |
+| `adjustmentPerGweiBaseFee` (DutchV3OrderFactory) | `0` for 5042 | Constant basefee (Correction B — set in the factory, not the cosigner). |
+| `WRAPPED_NATIVE_CURRENCY[5042]` | **do not populate** | No wrapped token exists; the ERC-20 interface *is* USDC. Hard-reject `0x0` sentinel at `src/api/quote/schema.ts` (Correction E / Tempo pattern) and require the `0x3600...0000` ERC-20 address. |
+| `PRIORITY_ORDER_TARGET_BLOCK_BUFFER[5042]`, `HYBRID_…[5042]` | `0` with comment | No Priority/Hybrid reactor; `validateReactorAddress` rejects upstream. |
+| `OLDEST_BLOCK_BY_CHAIN[5042]` (x-service) | ~`4829000` (block at 2026-06-12) | — |
+
+---
+
+## Notes
+
+- **Native-sentinel policy.** Unlike Tempo, `0x0` orders would mechanically work (reactor can transfer native USDC). Reject them anyway: output amounts for `0x0` would be 18-decimal native-USDC wei while every USDC integration on Arc speaks the 6-decimal ERC-20 — a silent 1e12 decimals mismatch waiting to happen. One asset, one address: `0x3600000000000000000000000000000000000000`, 6 decimals.
+- **Decimals trap is the #1 integration risk.** Quoting/accounting must treat Arc USDC as 6 decimals (ERC-20 interface). Anything reading `eth_getBalance` for USDC (filler balance checks, MIN_BALANCE-style preflights) gets 18-decimal units. `scripts/deploy-v3-multichain.sh`'s `MIN_BALANCE_WEI` happens to be safe (5e16 native ≈ $0.05).
+- **Stablecoin canary pairs.** USDC (`0x3600...0000`) is the anchor; confirm which other stables (EURC, USYC, etc.) are live on Arc mainnet with a PMM before picking the canary pair — docs list testnet assets only.
+- **Sample executors.** Mechanically functional, but their native-sweep paths sweep USDC; recommend MMs use ERC-20-only flows. Same guidance as Tempo, softer reason.
+- **Verification.** Confirm Arcscan's verifier API (Etherscan-compatible vs Blockscout) before deploy; `explorer.arc.io` redirect suggests a hosted explorer exists.
+- **Cosigner tripwire.** With a constant basefee, parameterization-api's (future) `startingBaseFee` divergence tripwire is trivially implementable for Arc — any observed value ≠ 2e10 is anomalous.

--- a/playbook/chains/robinhood.md
+++ b/playbook/chains/robinhood.md
@@ -1,0 +1,114 @@
+# Robinhood Chain (chainId 4663)
+
+Status: 🟢 **Contracts deployed 2026-06-12** — `V3DutchOrderReactor` at `0x000000007A1C8e570011EeDF86A2A35593013cBA` (owner + permit2 verified on-chain; built from post-`BlockNumberish`-4663 bytecode so decay reads `ArbSys.arbBlockNumber()`), `OrderQuoter` at canonical `0x00000000a3db63Df9078cBF3dF88B4CAdD5a7F58`. Explorer verification + SDK/service wiring (Phases 2–4) pending.
+
+Original audit assessment: 🟡 Has caveats. Arbitrum Orbit L2 on Ethereum (Nitro `v3.9.9`), ETH gas, Permit2 + Arachnid CREATE2 deployer present and functional. Two structural items, both now resolved:
+
+1. **`BlockNumberish.sol` decision** — Orbit chains have Arbitrum One's split block-number semantics (`block.number` = parent-chain estimate, `ArbSys.arbBlockNumber()` = L2 count), but `src/base/BlockNumberish.sol` only special-cased chainid 42161. **Resolved**: 4663 added to the ArbSys branch (Option A below) + fresh salt mined against the new bytecode; deployed. The 17 previously-deployed chains run the pre-change bytecode (unaffected); future chains mine against the new bytecode and the canonical Tempo salt is retired.
+2. **On-demand block production** — the chain is currently near-idle (~53K blocks total). Blocks arrive in sub-second bursts separated by multi-minute gaps. Block-driven V3 decay stalls when no blocks are produced. **Still the key launch-timing consideration** — see [Launch caveats](#launch-caveats).
+
+v4 **is** deployed (PoolManager `0x8366a39cc670b4001a1121b8f6a443a643e40951`, per sdk-core `ROBINHOOD_ADDRESSES`); `PoolManager.owner()` returns the canonical `0x2bad8182c09f50c8318d769245bea52c32be46cd` (verified live 2026-06-12) — standard owner-derivation flow applies. Note the owner address has no code on Robinhood (the deploy script warns EOA-on-chain but doesn't block; same as other canonical-owner chains).
+
+Source: live RPC probes against the QuikNode endpoint (2026-06-12) + [docs.robinhood.com/chain](https://docs.robinhood.com/chain/).
+
+---
+
+## §0 Pre-integration questionnaire
+
+| Question | Answer |
+|---|---|
+| **chainId** | `4663` (`0x1237`) — mainnet. (Testnet is `46630`.) |
+| **RPC + explorer URLs** | Probed via QuikNode: `https://dry-burned-surf.robinhood-mainnet.quiknode.pro/<key>/`. Public mainnet RPC + explorer URLs not yet published in docs (testnet: `rpc.testnet.chain.robinhood.com` / Blockscout at `explorer.testnet.chain.robinhood.com`) — **confirm mainnet equivalents with Robinhood before launch**. |
+| **Block time (target)** | **On-demand** (standard Nitro): blocks only when txs arrive, ≥4 blocks/s possible under load (observed sub-second bursts), but multi-minute idle gaps today (observed 298s gap at block 52943→52944; ~37s/block average over the last 2K blocks). Treat as 250ms *under load*, unbounded when idle. |
+| **Finality model** | Standard Orbit: sequencer soft-confirms instantly; Ethereum DA via blobs; L1 finality in ~13 min. Same trust model as Arbitrum One for filler purposes — treat sequencer receipt as final. |
+| **`block.number` semantics** | **Non-standard (Arbitrum-style)**: returns the sequencer's estimate of the *Ethereum L1* block number (observed `l1BlockNumber` ≈ 25,303,216 vs L2 height 52,851). `ArbSys(0x64).arbBlockNumber()` returns the L2 height (verified live: `0xce73`). `eth_blockNumber` returns the **L2** height — matches ArbSys, not `block.number`. Needs the `BlockNumberish.sol` branch (see below). |
+| **`block.basefee` semantics** | Real wei value, Orbit congestion pricing with a 0.1 gwei floor. Observed pinned at floor (`100000000`, one sample at `100020000`). Standard treatment — leave `adjustmentPerGweiBaseFee` default (it will be ~no-op at the floor, which is fine). |
+| **`block.timestamp` semantics** | Standard Unix seconds (sequencer-assigned, monotonic). Deadline math safe — advances in wall-clock even when block production is idle. |
+| **Native gas token** | ETH (docs: "Ethereum blobs for data availability and ETH as the native gas token"). `NATIVE` sentinel usable. Mainnet WETH at `0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73` (sdk-core `WETH9[4663]`; `symbol() == WETH` verified live). |
+| **`CALLVALUE` / `BALANCE` / `SELFBALANCE` opcodes** | Standard (Nitro). `payable` paths and sample-executor native sweeps work. |
+| **State creation costs** | Standard Nitro gas schedule. No special pricing concern. |
+| **Permit2 at canonical address?** | ✅ Yes — 9,152 bytes at `0x000000000022D473030F116dDEE9F6B43aC78BA3`, `DOMAIN_SEPARATOR()` returns non-zero (`0x4486...4fad`). |
+| **Sequencer / private mempool / pre-confs** | Centralized Robinhood-operated sequencer (standard Orbit). Sequencer feed exists (testnet: `wss://feed.testnet.chain.robinhood.com`). No public mempool — RFQ exclusivity via `ExclusivityLib` as usual; sequencer ordering risk same class as Arbitrum One pre-BoLD. |
+| **EIP-1559 / typed tx support** | ✅ Nitro supports type-2 txs; `baseFeePerGas` populated. |
+| **Routing surfaces (UniversalRouter, etc.)** | Uniswap v3 + v4 deployed per sdk-core `ROBINHOOD_ADDRESSES`: v4 PoolManager `0x8366a39cc670b4001a1121b8f6a443a643e40951` (24KB code verified live), v3 factory `0x1f7d...2efa`, SwapRouter02 `0xcaf6...5cb2`, v4 Quoter `0x8dc1...8f94`. Multicall3 ✅ at canonical `0xcA11...CA11`. Classic-route quote source exists. |
+| **protocolFeeOwner** | `0x2bad8182c09f50c8318d769245bea52c32be46cd` — derived from `PoolManager.owner()` (verified live 2026-06-12); happens to equal the canonical Arbitrum One owner. No code at that address on Robinhood (expected-multisig warning will fire; non-blocking). |
+
+---
+
+## §1 EVM compatibility audit
+
+| Behavior | Standard? | Notes for Robinhood |
+|---|---|---|
+| `block.number` monotonic & contiguous | ⚠️ **No** | Arbitrum-style L1-block estimate: coarse (~12s granularity), advances in jumps. `eth_blockNumber` (what off-chain services poll) returns the L2 height instead. **Requires the ArbSys branch in `src/base/BlockNumberish.sol`** (currently gated to chainid 42161 only). |
+| `block.basefee` real wei value | ✅ | Orbit pricing, 0.1 gwei floor, near-constant today. Standard treatment. |
+| `block.timestamp` seconds since epoch, monotonic | ✅ | Standard. |
+| `msg.value` reflects sent ETH | ✅ | Standard. |
+| `address(this).balance` reflects ETH balance | ✅ | Standard; sample-executor native sweeps fine. |
+| Permit2 deployed at canonical address | ✅ | Verified + functional. |
+| Arachnid CREATE2 deployer present | ✅ | 69 bytes at `0x4e59b44847b379578588920cA78FbF26c0B4956C`. |
+| EIP-1559 fields populated | ✅ | Standard Nitro. |
+| Canonical reactor address free | ✅ | No code at `0x000000005aF66799D1a6317714D66800f9CA1406` (moot — see salt note below). |
+
+---
+
+## BlockNumberish decision
+
+`V3DutchOrderReactor` resolves decay via `_getBlockNumberish()` (`src/reactors/V3DutchOrderReactor.sol:65`). On Robinhood the two candidate sources disagree:
+
+| | **Option A — add 4663 to the ArbSys branch (recommended)** | Option B — deploy unmodified (use `block.number`) |
+|---|---|---|
+| On-chain decay source | L2 block height (250ms granularity under load) | L1-block estimate (~12s granularity, mainnet-like) |
+| Off-chain consistency | ✅ `eth_blockNumber` == `arbBlockNumber` on Nitro — parameterization-api `decayStartBlock`, x-service polling, and the SDK all work unchanged (exactly like Arbitrum One) | ❌ `eth_blockNumber` (L2 height ≈ 53K) ≠ `block.number` (≈ 25.3M). Every off-chain consumer must switch to reading `l1BlockNumber` for this chain or cosigned orders resolve as fully-decayed/never-started. High-risk, invasive service changes. |
+| Idle-chain behavior | ⚠️ Decay stalls while no blocks are produced (L2 height freezes) | Decay tracks wall-clock via L1 estimate |
+| Bytecode impact | ⚠️ creationCode changes → fresh salt for Robinhood; canonical Tempo salt becomes invalid for any *future* chain deployed from the new bytecode (the 17 already-deployed chains are unaffected) | None |
+
+Option B's wall-clock decay is attractive in isolation, but it silently breaks the `eth_blockNumber`-based assumptions baked into parameterization-api, x-service, and the SDK — the bug class is "order instantly fully decayed," which is swapper-money-losing. Option A keeps Robinhood byte-for-byte consistent with the Arbitrum One mental model everywhere off-chain, and the idle-stall risk is bounded: deadlines are timestamp-based (they expire normally), RFQ-cosigned fills don't depend on decay progression, and any fill/trade activity itself produces blocks. Mitigate the stall with launch-timing + monitoring (below) rather than novel semantics.
+
+**The change** (in `src/base/BlockNumberish.sol`, constructor):
+
+```solidity
+uint256 private constant ARB_CHAIN_ID = 42161;
+uint256 private constant ROBINHOOD_CHAIN_ID = 4663;
+...
+if (block.chainid == ARB_CHAIN_ID || block.chainid == ROBINHOOD_CHAIN_ID) {
+    _getBlockNumberish = _getBlockNumberSyscall;
+}
+```
+
+(ArbSys is a Nitro precompile at `0x64` on every Orbit chain — `arbBlockNumber()` verified live on Robinhood mainnet.)
+
+Note the same 42161-only gating exists in `lib/blocknumberish` (used by `src/v4/resolvers/HybridAuctionResolver.sol`) — out of scope for the DutchV3 rollout but file an issue so v4 resolvers don't regress on Orbit chains later.
+
+**Ordering vs Arc:** Arc's PoolManager owner is *not* canonical, so Arc needs its own mining run regardless. Land this change first, then mine both chains' salts against the same bytecode/toolchain state (`./scripts/mine-salt.sh 4663 && ./scripts/mine-salt.sh 5042`). The in-script `predicted == V3_REACTOR_EXPECTED` assert makes any bytecode/salt mismatch fail safe (abort, no gas spent).
+
+---
+
+## Deploy parameters
+
+| Parameter | Value | Rationale |
+|---|---|---|
+| `FOUNDRY_REACTOR_OWNER` | `0x2bad8182c09f50c8318d769245bea52c32be46cd` | Derived from `PoolManager.owner()` at `0x8366a39cc670b4001a1121b8f6a443a643e40951`. |
+| `V3_REACTOR_SALT` / `V3_REACTOR_EXPECTED` | `0x...1585866b75f2b774c6520080` / `0x000000007A1C8e570011EeDF86A2A35593013cBA` — **mined + deployed 2026-06-12** (4 leading + 5 total zero bytes) | Mined against post-4663-branch bytecode (macOS + forge 1.4.4 + solc 0.8.30); deployer `0xA53247dEeC5884B5A10667dee1C378e729a93e03`, ~0.0011 ETH gas. |
+| Deploy route | `scripts/deploy-v3-multichain.sh` works (poolManager + owner now in salts.json; owner-drift precondition passes) — pass `RPC_4663=<url>` since `default_rpc()` has no 4663 entry. Direct single-chain invocation also fine. | — |
+| Lens | OrderQuoter — **canonical address `0x00000000a3db63Df9078cBF3dF88B4CAdD5a7F58` still works** | OrderQuoter doesn't inherit BlockNumberish; its initcode is unchanged → same salt/address as all other chains. Use `script/DeployOrderQuoter.s.sol`. |
+| Deployer gas funding | ETH on Robinhood (bridge via the chain's canonical bridge) | ~0.05 ETH headroom per `MIN_BALANCE_WEI` convention. |
+| `BLOCK_TIME_MS_BY_CHAIN[4663]` (x-service) | `250` | Nitro under-load cadence; mirror Arbitrum One's entry. |
+| `AVERAGE_BLOCK_TIME(4663)` (x-service) | mirror Arbitrum One | Same Nitro semantics. |
+| `MIN_RETRY_WAIT_SECONDS_<CHAIN>` floor | **needed** (sub-second blocks under load) — mirror whatever Arbitrum One does today; if Arbitrum has no floor, add `2` for 4663 | Correction D: Step Functions Wait rounds sub-second to 0 → hot loop. |
+| `V3_BLOCK_LENGTH_BY_CHAIN[4663]` (trading-api) | `120` (= 30s at 250ms), Arbitrum parity | Wallclock-correct only under load; see launch caveats. |
+| `V3_BLOCK_BUFFER` (parameterization-api) | mirror Arbitrum One's value | Same block cadence + `eth_blockNumber` semantics under Option A. |
+| `getBlockTimeSecs(4663)` (parameterization-api) | `0.25` | — |
+| `GAS_COMPARISON_MULTIPLIER_BY_CHAIN[4663]` | `1.0` (default) | Real wei basefee; gas is cheap but not denominated weirdly. |
+| `WRAPPED_NATIVE_CURRENCY[4663]` | WETH `0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73` | sdk-core `WETH9[4663]`, symbol verified live. Native ETH is real; do *not* reject the native sentinel. |
+| `adjustmentPerGweiBaseFee` (DutchV3OrderFactory) | default (non-zero path) | Standard wei basefee. Near-no-op at the 0.1 gwei floor — harmless. |
+| `PRIORITY_ORDER_TARGET_BLOCK_BUFFER[4663]`, `HYBRID_…[4663]` | `0` with comment | No Priority/Hybrid reactor at launch; `validateReactorAddress` rejects upstream. |
+| `OLDEST_BLOCK_BY_CHAIN[4663]` (x-service) | ~`52900` (block at 2026-06-12) | Chain is brand new. |
+
+---
+
+## Launch caveats
+
+- **Decay stalls on an idle chain.** Under Option A, V3 decay advances one step per L2 block. Today the chain idles for minutes at a time → a "30s" (120-block) decay can take arbitrarily long, so open-market price improvement degrades to "sit at cosigned start price until deadline." RFQ-cosigned fills are unaffected (filler fills at the cosigned override immediately), and order deadlines expire on wall-clock as normal. **Recommendation:** launch UniswapX only once baseline Robinhood activity sustains regular block production, or accept RFQ-dominant behavior at first; add a dashboard panel for L2 blocks/minute and alert if decay-window wallclock (decayStartBlock → currentBlock × 250ms vs. real elapsed time) diverges >5×.
+- **Public mainnet RPC + explorer unpublished.** Robinhood's public docs are testnet-only as of 2026-06-12 (Blockscout expected for mainnet, mirroring testnet). Collect from the Robinhood team; verify explorer supports contract verification before the deploy (Blockscout: `forge verify-contract --verifier blockscout --verifier-url <explorer>/api`).
+- **sdk-core is a no-op**: `ChainId.ROBINHOOD = 4663` is already in `@uniswap/sdk-core` with the full v3/v4 `ROBINHOOD_ADDRESSES` block and `WETH9[4663]`. Phase 1 reduces to the x-contracts deploy.
+- **Classic routing exists** (v3 + v4 + SwapRouter02 live on-chain), so `compareQuotes` has a real Classic leg. Confirm the routing stack (URA/trading-api Classic path) is actually serving Robinhood quotes before flipping the flag.

--- a/playbook/chains/salts.json
+++ b/playbook/chains/salts.json
@@ -103,6 +103,29 @@
       "gasEstimateMultiplier": 500,
       "_gasNote": "Tempo charges ~1000 gas/byte for code deposit vs 200 on standard EVM, so forge's default 130% gas estimate is short of actual on-chain cost. 5x ensures the broadcast tx has enough gas headroom to deposit the runtime code. Other chains use forge's default."
     },
+    "4663": {
+      "name": "robinhood",
+      "poolManager": "0x8366a39cc670b4001a1121b8f6a443a643e40951",
+      "owner": "0x2bad8182c09f50c8318d769245bea52c32be46cd",
+      "salt": "0x00000000000000000000000000000000000000001585866b75f2b774c6520080",
+      "expectedReactor": "0x000000007A1C8e570011EeDF86A2A35593013cBA",
+      "minedAt": "2026-06-12T23:10:10Z",
+      "_ownerSource": "PoolManager.owner() verified live 2026-06-12. Owner is the canonical 0x2bad...46cd but has NO code on Robinhood (deploy script warns EOA-on-chain; same situation as other canonical-owner chains).",
+      "_saltNote": "Salt mined against POST-BlockNumberish-4663 bytecode (Robinhood is Arbitrum Orbit; src/base/BlockNumberish.sol routes 4663 through ArbSys). This reactor's creationCode differs from the 17 chains deployed before the 4663 branch — do not expect address parity. Future chains must also mine against the new bytecode; the canonical Tempo salt is retired.",
+      "_deployNote": "DEPLOYED 2026-06-12 (reactor + canonical OrderQuoter 0x00000000a3db63Df9078cBF3dF88B4CAdD5a7F58). See playbook/chains/robinhood.md.",
+      "minedZeroBytes": "4 leading + 5 total"
+    },
+    "5042": {
+      "name": "arc",
+      "poolManager": "0x8366a39cc670b4001a1121b8f6a443a643e40951",
+      "owner": "0x33f26c5d69e2c40956f22c6195b6a499cf4151e8",
+      "salt": "0x0000000000000000000000000000000000000000179cec38645d390d013a0040",
+      "expectedReactor": "0x0000000015134054eA82AE0bb9fda66b36402C36",
+      "minedAt": "2026-06-12T22:57:34Z",
+      "_ownerSource": "PoolManager.owner() verified live 2026-06-12; owner is a contract on Arc (171-byte proxy, likely Safe). NOT the canonical owner — canonical salt does not apply; fresh pair mined via scripts/mine-salt.sh 5042.",
+      "_deployNote": "DEPLOYED 2026-06-12 (reactor + canonical OrderQuoter 0x00000000a3db63Df9078cBF3dF88B4CAdD5a7F58). Mined and deployed against pre-BlockNumberish-4663 bytecode (Arc-first ordering); the later 4663 branch does not affect this deployed reactor. Deployer gas on Arc is native USDC. See playbook/chains/arc.md.",
+      "minedZeroBytes": "4 leading + 4 total"
+    },
     "8453": {
       "name": "base",
       "poolManager": "0x498581ff718922c3f8e6a244956af099b2652b2b",

--- a/src/base/BlockNumberish.sol
+++ b/src/base/BlockNumberish.sol
@@ -11,11 +11,15 @@ contract BlockNumberish {
     function() view returns (uint256) internal immutable _getBlockNumberish;
 
     uint256 private constant ARB_CHAIN_ID = 42161;
+    // Robinhood Chain is an Arbitrum Orbit L2: same split block-number
+    // semantics as Arbitrum One (block.number returns the parent-chain
+    // estimate; ArbSys returns the L2 height).
+    uint256 private constant ROBINHOOD_CHAIN_ID = 4663;
     address private constant ARB_SYS_ADDRESS = 0x0000000000000000000000000000000000000064;
 
     constructor() {
         // Set the function to use based on chainid
-        if (block.chainid == ARB_CHAIN_ID) {
+        if (block.chainid == ARB_CHAIN_ID || block.chainid == ROBINHOOD_CHAIN_ID) {
             _getBlockNumberish = _getBlockNumberSyscall;
         } else {
             _getBlockNumberish = _getBlockNumber;

--- a/test/base/BlockNumberish.t.sol
+++ b/test/base/BlockNumberish.t.sol
@@ -32,4 +32,12 @@ contract BlockNumberishTest is Test {
         arbSys.setBlockNumber(1);
         assertEq(blockNumberish.getBlockNumberish(), 1);
     }
+
+    function test_getBlockNumberSyscall_robinhood() public {
+        vm.chainId(4663);
+        blockNumberish = new MockBlockNumberish();
+
+        arbSys.setBlockNumber(7);
+        assertEq(blockNumberish.getBlockNumberish(), 7);
+    }
 }

--- a/test/integration/V3DutchOrderIntegration.t.sol
+++ b/test/integration/V3DutchOrderIntegration.t.sol
@@ -151,15 +151,15 @@ contract V3DutchOrderIntegrationTest is Test, PermitSignature {
         quoter = OrderQuoter(payable(quoterAddr));
         permit2 = IPermit2(CANONICAL_PERMIT2);
 
-        // Arbitrum-only: the reactor's `BlockNumberish` mixin captures the
-        // chainid at deploy time and routes block-number reads through the
-        // ArbSys precompile (0x64) on chain 42161. Foundry's local EVM
-        // doesn't implement Arbitrum precompiles, so any forked call from
-        // the reactor that needs a block number reverts with InvalidFEOpcode.
-        // Mock the precompile to return the L1 block number — the test
-        // orders don't have meaningful decay (start == end), so the value
-        // only needs to be non-reverting and monotonic.
-        if (block.chainid == 42161) {
+        // Arbitrum Orbit chains: the reactor's `BlockNumberish` mixin captures
+        // the chainid at deploy time and routes block-number reads through the
+        // ArbSys precompile (0x64) on Arbitrum One (42161) and Robinhood
+        // (4663). Foundry's local EVM doesn't implement Arbitrum precompiles,
+        // so any forked call from the reactor that needs a block number reverts
+        // with InvalidFEOpcode. Mock the precompile to return the L1 block
+        // number — the test orders don't have meaningful decay (start == end),
+        // so the value only needs to be non-reverting and monotonic.
+        if (block.chainid == 42161 || block.chainid == 4663) {
             vm.mockCall(address(0x64), abi.encodeWithSignature("arbBlockNumber()"), abi.encode(block.number));
         }
 


### PR DESCRIPTION
## Summary

Deploys `V3DutchOrderReactor` + `OrderQuoter` to **Robinhood Chain (4663)** and **Arc (5042)**, following `playbook/NEW_CHAIN.md`. Both chains were audited live (§0 questionnaire + §1 EVM audit against mainnet RPCs); research files added under `playbook/chains/`.

| | Robinhood (4663) | Arc (5042) |
|---|---|---|
| Reactor | `0x000000007A1C8e570011EeDF86A2A35593013cBA` | `0x0000000015134054eA82AE0bb9fda66b36402C36` |
| OrderQuoter | `0x00000000a3db63Df9078cBF3dF88B4CAdD5a7F58` (canonical) | `0x00000000a3db63Df9078cBF3dF88B4CAdD5a7F58` (canonical) |
| protocolFeeOwner (= `PoolManager.owner()`) | `0x2bad...46cd` (canonical) | `0x33f2...51e8` (Safe proxy on Arc) |

`owner()` / `permit2()` / code size verified on-chain post-broadcast. Tx hashes in `deployments.md`.

## Code change: `BlockNumberish` 4663 branch

Robinhood is an **Arbitrum Orbit** chain: `block.number` returns the parent-chain (Ethereum) block estimate, while `eth_blockNumber`/`ArbSys` return the L2 height. This PR routes chainId 4663 through the existing ArbSys syscall branch so V3 decay ticks on L2 blocks and stays consistent with every off-chain consumer — identical semantics to Arbitrum One. New unit test covers the 4663 path; all 59 V3DutchOrder tests pass.

**Consequence:** the reactor creationCode changed, so the canonical Tempo salt is retired — future chains must mine fresh salts (noted in `salts.json`). The 17 previously deployed chains are unaffected. Arc was mined + deployed *before* this change landed (Arc-first ordering; behaviorally equivalent on Arc, which has standard `block.number`).

## Arc chain quirks (documented in `playbook/chains/arc.md`)

- USDC is the native gas token with dual representation: 18-decimal native, 6-decimal ERC-20 predeploy at `0x3600...0000` over the same balance (verified on-chain). Service rollout must reject the `0x0` sentinel and use the ERC-20 address.
- `block.basefee` constant at 20 gwei (native-USDC wei) across 1M+ blocks → `adjustmentPerGweiBaseFee = 0` at order construction, gas-comparison multiplier 0 (Tempo pattern).
- ~500ms blocks → Tempo-style sub-second retry floor.

## Follow-ups (not in this PR)

- Explorer verification for both chains (mainnet explorer URLs not yet published; Blockscout expected for Robinhood, Arcscan for Arc)
- uniswapx-sdk constants entries (Phase 2), then param-api/x-service/trading-api wiring (Phase 3) per the playbook
- Robinhood launch timing: chain is near-idle today (multi-minute block gaps) — block-driven decay stalls when idle; recommend the blocks-per-minute dashboard panel before flag flip
- `lib/blocknumberish` (used by v4 `HybridAuctionResolver`) still gates on 42161 only — file an issue so v4 resolvers don't regress on Orbit chains

## Test plan

- `forge test --match-path test/base/BlockNumberish.t.sol` — 3 passed (incl. new 4663 case)
- `forge test --match-contract V3DutchOrder` — 59 passed
- Pre-broadcast CREATE2 `predicted == expected` assertions passed on both chains; post-broadcast on-chain verification of `owner()`, `permit2()`, code size

🤖 Generated with [Claude Code](https://claude.com/claude-code)