### PR TITLE
feat: authenticate cast RPC calls with x-internal-service-secret header

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -19,9 +19,12 @@ Both workflows:
 
 Unit tests also run `forge fmt --check` and build calibur submodule first.
 
+Integration tests run `forge test` through `scripts/with-rpc-header-proxy.sh`, which points `FOUNDRY_RPC_URL` at a local proxy (`scripts/rpc-header-proxy.py`) injecting the `x-internal-service-secret` header — the RPC endpoint requires it and Foundry's forking code has no native way to send custom headers.
+
 ## Required Secrets
 
-- `RPC_URL` - Required for integration tests (mainnet fork)
+- `RPC_URL` - Required for integration tests (mainnet fork); forwarded to the wrapper as `UPSTREAM_RPC_URL`
+- `RPC_HEADER_SECRET` - Value sent as the `x-internal-service-secret` header on integration-test RPC calls
 
 ## Security
 

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -52,8 +52,9 @@ jobs:
 
       - name: Run Forge integration tests
         run: |
-          forge test -vvv
+          scripts/with-rpc-header-proxy.sh forge test -vvv
         env:
-          FOUNDRY_RPC_URL: "${{ secrets.RPC_URL }}"
+          UPSTREAM_RPC_URL: "${{ secrets.RPC_URL }}"
+          RPC_HEADER_SECRET: "${{ secrets.RPC_HEADER_SECRET }}"
           FOUNDRY_PROFILE: integration
         id: integration

--- a/scripts/deploy-quoter-multichain.sh
+++ b/scripts/deploy-quoter-multichain.sh
@@ -36,8 +36,14 @@
 #   RPC_HEADER_SECRET=<value>    sent as the `x-internal-service-secret`
 #                                header on `cast` RPC calls (read-only
 #                                preconditions). NOT sent on `forge script`
-#                                calls (simulation/broadcast) — Foundry has no
-#                                mechanism to attach custom headers there.
+#                                calls (simulation/broadcast) — cast supports
+#                                custom headers natively but forge script
+#                                doesn't. These scripts target public
+#                                per-chain RPCs that don't need it; if yours
+#                                does, wrap the forge script invocation with
+#                                scripts/with-rpc-header-proxy.sh instead
+#                                (see .github/workflows/test-integration.yml
+#                                for a working example).
 #
 # Usage:
 #   DEPLOYER_MNEMONIC="word1 word2 ..." ./scripts/deploy-quoter-multichain.sh

--- a/scripts/deploy-quoter-multichain.sh
+++ b/scripts/deploy-quoter-multichain.sh
@@ -33,6 +33,11 @@
 #   DRY_RUN=1                    runs preconditions + simulation, no broadcast
 #   MIN_BALANCE_WEI=<value>      default 5e16 (~0.05 ETH-equivalent)
 #   RPC_<chainId>=<url>          override the public RPC for a chain
+#   RPC_HEADER_SECRET=<value>    sent as the `x-internal-service-secret`
+#                                header on `cast` RPC calls (read-only
+#                                preconditions). NOT sent on `forge script`
+#                                calls (simulation/broadcast) — Foundry has no
+#                                mechanism to attach custom headers there.
 #
 # Usage:
 #   DEPLOYER_MNEMONIC="word1 word2 ..." ./scripts/deploy-quoter-multichain.sh
@@ -48,6 +53,14 @@ ARACHNID=0x4e59b44847b379578588920cA78FbF26c0B4956C
 EXPECTED_QUOTER=0x00000000a3db63Df9078cBF3dF88B4CAdD5a7F58
 MIN_BALANCE_WEI=${MIN_BALANCE_WEI:-50000000000000000}
 DRY_RUN=${DRY_RUN:-0}
+
+# Authenticates `cast` RPC calls against internal providers. Omitted when
+# unset (public RPCs / local dev). Not applied to forge script — see the
+# RPC_HEADER_SECRET note in the Optional env block above.
+RPC_HEADERS_ARGS=()
+if [[ -n "${RPC_HEADER_SECRET:-}" ]]; then
+  RPC_HEADERS_ARGS=(--rpc-headers "x-internal-service-secret: ${RPC_HEADER_SECRET}")
+fi
 
 # Default RPCs per chain; override with RPC_<chainId>=<url>. Function-based
 # so the script works under bash 3.2 (macOS default).
@@ -126,7 +139,7 @@ for chainid in $CHAINS; do
   echo "=== chain $chainid — $rpc ==="
 
   # 1. RPC reachable + correct chainId
-  observed_chainid_hex=$(cast chain-id --rpc-url "$rpc" 2>/dev/null || echo "")
+  observed_chainid_hex=$(cast chain-id --rpc-url "$rpc" ${RPC_HEADERS_ARGS[@]+"${RPC_HEADERS_ARGS[@]}"} 2>/dev/null || echo "")
   if [[ -z "$observed_chainid_hex" ]]; then
     echo "  [SKIP] RPC unreachable"
     results+=("$chainid|SKIP-RPC-UNREACHABLE")
@@ -140,7 +153,7 @@ for chainid in $CHAINS; do
   fi
 
   # 2. Already deployed?
-  quoter_code=$(cast code "$EXPECTED_QUOTER" --rpc-url "$rpc" 2>/dev/null || echo "0x")
+  quoter_code=$(cast code "$EXPECTED_QUOTER" --rpc-url "$rpc" ${RPC_HEADERS_ARGS[@]+"${RPC_HEADERS_ARGS[@]}"} 2>/dev/null || echo "0x")
   if [[ ${#quoter_code} -gt 4 ]]; then
     echo "  [SKIP] quoter already at $EXPECTED_QUOTER"
     results+=("$chainid|SKIP-ALREADY-DEPLOYED")
@@ -148,7 +161,7 @@ for chainid in $CHAINS; do
   fi
 
   # 3. Arachnid factory present
-  arachnid_code=$(cast code "$ARACHNID" --rpc-url "$rpc" 2>/dev/null || echo "0x")
+  arachnid_code=$(cast code "$ARACHNID" --rpc-url "$rpc" ${RPC_HEADERS_ARGS[@]+"${RPC_HEADERS_ARGS[@]}"} 2>/dev/null || echo "0x")
   if [[ ${#arachnid_code} -le 4 ]]; then
     echo "  [SKIP] Arachnid CREATE2 factory not deployed"
     results+=("$chainid|SKIP-NO-ARACHNID")
@@ -156,7 +169,7 @@ for chainid in $CHAINS; do
   fi
 
   # 4. Wallet balance
-  balance=$(cast balance "$DEPLOYER" --rpc-url "$rpc" 2>/dev/null || echo "0")
+  balance=$(cast balance "$DEPLOYER" --rpc-url "$rpc" ${RPC_HEADERS_ARGS[@]+"${RPC_HEADERS_ARGS[@]}"} 2>/dev/null || echo "0")
   if [[ -z "$balance" ]]; then balance=0; fi
   if [[ "$(ge "$balance" "$MIN_BALANCE_WEI")" != "True" ]]; then
     eth_balance=$(python3 -c "print(int('$balance')/1e18)" 2>/dev/null || echo "?")

--- a/scripts/deploy-v3-multichain.sh
+++ b/scripts/deploy-v3-multichain.sh
@@ -48,6 +48,11 @@
 #                                stops short of broadcasting.
 #   MIN_BALANCE_WEI=<value>      default 5e16 (~0.05 ETH-equivalent).
 #   RPC_<chainId>=<url>          override the public RPC for a chain.
+#   RPC_HEADER_SECRET=<value>    sent as the `x-internal-service-secret`
+#                                header on `cast` RPC calls (read-only
+#                                preconditions). NOT sent on `forge script`
+#                                calls (simulation/broadcast) — Foundry has no
+#                                mechanism to attach custom headers there.
 #   SALTS_JSON=<path>            override salts.json path
 #                                (default: playbook/chains/salts.json).
 #
@@ -68,6 +73,14 @@ ARACHNID=0x4e59b44847b379578588920cA78FbF26c0B4956C
 SALTS_JSON=${SALTS_JSON:-playbook/chains/salts.json}
 MIN_BALANCE_WEI=${MIN_BALANCE_WEI:-50000000000000000} # ~0.05 ETH-equivalent
 DRY_RUN=${DRY_RUN:-0}
+
+# Authenticates `cast` RPC calls against internal providers. Omitted when
+# unset (public RPCs / local dev). Not applied to forge script — see the
+# RPC_HEADER_SECRET note in the Optional env block above.
+RPC_HEADERS_ARGS=()
+if [[ -n "${RPC_HEADER_SECRET:-}" ]]; then
+  RPC_HEADERS_ARGS=(--rpc-headers "x-internal-service-secret: ${RPC_HEADER_SECRET}")
+fi
 
 # Default RPCs per chain. Override with RPC_<chainId>=<url> at invocation time.
 # Function-based lookup (instead of `declare -A`) so the script works under
@@ -151,7 +164,7 @@ for chainid in $chain_ids; do
   echo "=== $name ($chainid) — $rpc ==="
 
   # 1. RPC reachable + correct chainId
-  observed_chainid_hex=$(cast chain-id --rpc-url "$rpc" 2>/dev/null || echo "")
+  observed_chainid_hex=$(cast chain-id --rpc-url "$rpc" ${RPC_HEADERS_ARGS[@]+"${RPC_HEADERS_ARGS[@]}"} 2>/dev/null || echo "")
   if [[ -z "$observed_chainid_hex" ]]; then
     echo "  [SKIP] RPC unreachable"
     results+=("$name|$chainid|SKIP-RPC-UNREACHABLE")
@@ -183,7 +196,7 @@ for chainid in $chain_ids; do
 
   # 3. PoolManager.owner() at runtime must match salts.json `owner`. If the
   # AMM owner has rotated since mining, the salt is stale.
-  observed_owner=$(cast call "$pool_manager" "owner()(address)" --rpc-url "$rpc" 2>/dev/null || echo "")
+  observed_owner=$(cast call "$pool_manager" "owner()(address)" --rpc-url "$rpc" ${RPC_HEADERS_ARGS[@]+"${RPC_HEADERS_ARGS[@]}"} 2>/dev/null || echo "")
   if [[ -z "$observed_owner" ]]; then
     echo "  [SKIP] PoolManager.owner() lookup failed at $pool_manager"
     results+=("$name|$chainid|SKIP-POOLMANAGER-LOOKUP-FAILED")
@@ -197,7 +210,7 @@ for chainid in $chain_ids; do
   fi
 
   # 4. Already deployed?
-  reactor_code=$(cast code "$expected_reactor" --rpc-url "$rpc" 2>/dev/null || echo "0x")
+  reactor_code=$(cast code "$expected_reactor" --rpc-url "$rpc" ${RPC_HEADERS_ARGS[@]+"${RPC_HEADERS_ARGS[@]}"} 2>/dev/null || echo "0x")
   if [[ "$reactor_code" != "0x" && -n "$reactor_code" ]]; then
     echo "  [SKIP] reactor already deployed at $expected_reactor"
     results+=("$name|$chainid|SKIP-ALREADY-DEPLOYED")
@@ -205,7 +218,7 @@ for chainid in $chain_ids; do
   fi
 
   # 5a. Permit2 code present
-  permit2_code=$(cast code "$PERMIT2" --rpc-url "$rpc" 2>/dev/null || echo "0x")
+  permit2_code=$(cast code "$PERMIT2" --rpc-url "$rpc" ${RPC_HEADERS_ARGS[@]+"${RPC_HEADERS_ARGS[@]}"} 2>/dev/null || echo "0x")
   if [[ "$permit2_code" == "0x" || -z "$permit2_code" ]]; then
     echo "  [SKIP] Permit2 not deployed at canonical address"
     results+=("$name|$chainid|SKIP-NO-PERMIT2")
@@ -213,7 +226,7 @@ for chainid in $chain_ids; do
   fi
 
   # 5b. Permit2 functional
-  permit2_ds=$(cast call "$PERMIT2" "DOMAIN_SEPARATOR()(bytes32)" --rpc-url "$rpc" 2>/dev/null || echo "")
+  permit2_ds=$(cast call "$PERMIT2" "DOMAIN_SEPARATOR()(bytes32)" --rpc-url "$rpc" ${RPC_HEADERS_ARGS[@]+"${RPC_HEADERS_ARGS[@]}"} 2>/dev/null || echo "")
   if [[ -z "$permit2_ds" || "$permit2_ds" == "0x"$(printf '0%.0s' {1..64}) ]]; then
     echo "  [SKIP] Permit2.DOMAIN_SEPARATOR() did not return a valid bytes32 (squatter/non-ABI-compatible contract?)"
     results+=("$name|$chainid|SKIP-PERMIT2-INVALID")
@@ -221,7 +234,7 @@ for chainid in $chain_ids; do
   fi
 
   # 6. Arachnid factory present
-  arachnid_code=$(cast code "$ARACHNID" --rpc-url "$rpc" 2>/dev/null || echo "0x")
+  arachnid_code=$(cast code "$ARACHNID" --rpc-url "$rpc" ${RPC_HEADERS_ARGS[@]+"${RPC_HEADERS_ARGS[@]}"} 2>/dev/null || echo "0x")
   if [[ "$arachnid_code" == "0x" || -z "$arachnid_code" ]]; then
     echo "  [SKIP] Arachnid CREATE2 factory not deployed"
     results+=("$name|$chainid|SKIP-NO-ARACHNID")
@@ -229,7 +242,7 @@ for chainid in $chain_ids; do
   fi
 
   # 7. Wallet balance
-  balance=$(cast balance "$DEPLOYER" --rpc-url "$rpc" 2>/dev/null || echo "0")
+  balance=$(cast balance "$DEPLOYER" --rpc-url "$rpc" ${RPC_HEADERS_ARGS[@]+"${RPC_HEADERS_ARGS[@]}"} 2>/dev/null || echo "0")
   if [[ -z "$balance" ]]; then balance=0; fi
   if [[ "$(ge "$balance" "$MIN_BALANCE_WEI")" != "True" ]]; then
     eth_balance=$(python3 -c "print(int('$balance')/1e18)" 2>/dev/null || echo "?")
@@ -243,7 +256,7 @@ for chainid in $chain_ids; do
   echo "  balance:  $balance wei (~${eth_balance} native)"
 
   # 8. Owner sanity (warn if EOA)
-  owner_code=$(cast code "$owner" --rpc-url "$rpc" 2>/dev/null || echo "0x")
+  owner_code=$(cast code "$owner" --rpc-url "$rpc" ${RPC_HEADERS_ARGS[@]+"${RPC_HEADERS_ARGS[@]}"} 2>/dev/null || echo "0x")
   if [[ "$owner_code" == "0x" || -z "$owner_code" ]]; then
     echo "  [WARN] owner $owner is an EOA on this chain (expected: multisig). Continuing."
   else

--- a/scripts/deploy-v3-multichain.sh
+++ b/scripts/deploy-v3-multichain.sh
@@ -51,8 +51,14 @@
 #   RPC_HEADER_SECRET=<value>    sent as the `x-internal-service-secret`
 #                                header on `cast` RPC calls (read-only
 #                                preconditions). NOT sent on `forge script`
-#                                calls (simulation/broadcast) — Foundry has no
-#                                mechanism to attach custom headers there.
+#                                calls (simulation/broadcast) — cast supports
+#                                custom headers natively but forge script
+#                                doesn't. These scripts target public
+#                                per-chain RPCs that don't need it; if yours
+#                                does, wrap the forge script invocation with
+#                                scripts/with-rpc-header-proxy.sh instead
+#                                (see .github/workflows/test-integration.yml
+#                                for a working example).
 #   SALTS_JSON=<path>            override salts.json path
 #                                (default: playbook/chains/salts.json).
 #

--- a/scripts/rpc-header-proxy.py
+++ b/scripts/rpc-header-proxy.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Local HTTP proxy that injects one static header onto every request before
+forwarding it to an upstream JSON-RPC endpoint.
+
+Foundry's forking and broadcast code paths (`vm.createSelectFork`, `forge
+script --rpc-url`) build their RPC provider straight from a URL string with
+no way to attach custom headers — see the RPC_HEADER_SECRET comments in
+scripts/deploy-v3-multichain.sh and scripts/with-rpc-header-proxy.sh. This
+proxy exists so those code paths can still reach an RPC endpoint that
+requires a header (e.g. x-internal-service-secret) by pointing FOUNDRY_RPC_URL
+at 127.0.0.1 instead of the upstream endpoint directly.
+
+Usage: rpc-header-proxy.py <upstream_url> <header_name> <header_value> <port>
+Prints "READY <port>" once listening, then serves until killed.
+"""
+import sys
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+UPSTREAM_URL, HEADER_NAME, HEADER_VALUE, PORT = sys.argv[1:5]
+
+
+class ProxyHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        body = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        req = urllib.request.Request(UPSTREAM_URL, data=body, method="POST")
+        req.add_header("Content-Type", self.headers.get("Content-Type", "application/json"))
+        req.add_header(HEADER_NAME, HEADER_VALUE)
+        try:
+            with urllib.request.urlopen(req) as resp:
+                self._respond(resp.status, resp.headers.get("Content-Type"), resp.read())
+        except urllib.error.HTTPError as e:
+            self._respond(e.code, "application/json", e.read())
+
+    def _respond(self, status, content_type, payload):
+        self.send_response(status)
+        self.send_header("Content-Type", content_type or "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, format, *args):  # keep CI logs quiet
+        pass
+
+
+if __name__ == "__main__":
+    server = ThreadingHTTPServer(("127.0.0.1", int(PORT)), ProxyHandler)
+    print(f"READY {PORT}", flush=True)
+    server.serve_forever()

--- a/scripts/with-rpc-header-proxy.sh
+++ b/scripts/with-rpc-header-proxy.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# with-rpc-header-proxy.sh — run a command with FOUNDRY_RPC_URL pointed at a
+# local proxy that injects the x-internal-service-secret header onto every
+# forwarded RPC request, then exec the command.
+#
+# Why this exists: some internal RPC endpoints (e.g. the backend gateway used
+# by CI integration tests) now reject requests missing
+# x-internal-service-secret. `cast` can send custom headers natively
+# (--rpc-headers / ETH_RPC_HEADERS), but `forge test`'s forking
+# (vm.createSelectFork) and `forge script --rpc-url` build their RPC provider
+# straight from the URL string with no header support at all — confirmed by
+# reading the Foundry source (crates/evm/core/src/fork/multi.rs,
+# crates/script/src/{execute,broadcast}.rs all call
+# get_http_provider(url)/ProviderBuilder::new(url) with no headers attached).
+# scripts/rpc-header-proxy.py is a small local HTTP proxy that adds the
+# header before forwarding, so pointing FOUNDRY_RPC_URL at 127.0.0.1 gets the
+# header to the upstream endpoint regardless of which Foundry code path is
+# making the request.
+#
+# Required env:
+#   UPSTREAM_RPC_URL     the real RPC endpoint to forward to
+#
+# Optional env:
+#   RPC_HEADER_SECRET    value for the x-internal-service-secret header. If
+#                        unset, runs the command against UPSTREAM_RPC_URL
+#                        directly (no proxy) — matches public-RPC/local-dev
+#                        usage where no header is required.
+#
+# Usage:
+#   UPSTREAM_RPC_URL=https://... RPC_HEADER_SECRET=... \
+#     scripts/with-rpc-header-proxy.sh forge test -vvv
+
+set -uo pipefail
+
+if [[ -z "${UPSTREAM_RPC_URL:-}" ]]; then
+  echo "UPSTREAM_RPC_URL not set" >&2
+  exit 1
+fi
+if [[ $# -eq 0 ]]; then
+  echo "usage: $0 <command> [args...]" >&2
+  exit 1
+fi
+
+if [[ -z "${RPC_HEADER_SECRET:-}" ]]; then
+  export FOUNDRY_RPC_URL="$UPSTREAM_RPC_URL"
+  exec "$@"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
+
+python3 "$SCRIPT_DIR/rpc-header-proxy.py" "$UPSTREAM_RPC_URL" "x-internal-service-secret" "$RPC_HEADER_SECRET" "$PORT" &
+proxy_pid=$!
+trap 'kill "$proxy_pid" 2>/dev/null' EXIT
+
+# Wait for the proxy socket to accept connections (max ~5s).
+ready=0
+for _ in $(seq 1 50); do
+  if ! kill -0 "$proxy_pid" 2>/dev/null; then
+    echo "rpc-header-proxy.py exited before starting" >&2
+    exit 1
+  fi
+  if (exec 3<>"/dev/tcp/127.0.0.1/${PORT}") 2>/dev/null; then
+    exec 3>&-
+    ready=1
+    break
+  fi
+  sleep 0.1
+done
+if [[ "$ready" != "1" ]]; then
+  echo "rpc-header-proxy.py did not become ready on port $PORT" >&2
+  exit 1
+fi
+
+export FOUNDRY_RPC_URL="http://127.0.0.1:${PORT}"
+"$@"


### PR DESCRIPTION
## Summary

- Adds an optional `RPC_HEADER_SECRET` env var to `scripts/deploy-v3-multichain.sh` and `scripts/deploy-quoter-multichain.sh`, sent as the `x-internal-service-secret` header on every `cast` RPC preflight call (`chain-id`, `code`, `call`, `balance`) via `cast`'s native `--rpc-headers` flag. Omitted when unset, so public-RPC / local-dev usage is unchanged. Mirrors [Uniswap/uniswapx-parameterization-api#442](https://github.com/Uniswap/uniswapx-parameterization-api/pull/442), adapted to this repo's Foundry tooling.
- Fixes `.github/workflows/test-integration.yml`, which started failing with `401 Unauthorized: Missing required header x-internal-service-secret` once the RPC gateway began enforcing the header on every request. `forge test`'s forking (`vm.createSelectFork`) builds its RPC provider straight from the URL string with no way to attach custom headers — confirmed by reading the Foundry source (`crates/evm/core/src/fork/multi.rs`) — so `cast`'s native `--rpc-headers` doesn't help here; forking never goes through `cast`.

## The fix: a local header-injecting proxy

- `scripts/rpc-header-proxy.py` — a small stdlib-only local HTTP proxy that adds `x-internal-service-secret` to every forwarded JSON-RPC request.
- `scripts/with-rpc-header-proxy.sh` — starts the proxy and points `FOUNDRY_RPC_URL` at `127.0.0.1` for a wrapped command, so it works regardless of which Foundry code path makes the request. No-ops (runs the command against `UPSTREAM_RPC_URL` directly) when `RPC_HEADER_SECRET` is unset.
- `test-integration.yml` now runs `scripts/with-rpc-header-proxy.sh forge test -vvv` with `UPSTREAM_RPC_URL: secrets.RPC_URL` and `RPC_HEADER_SECRET: secrets.RPC_HEADER_SECRET`.
- The two deploy scripts target public per-chain RPCs for `forge script` broadcasts, which don't need the header, so they're left as `cast`-only; their comments point at `with-rpc-header-proxy.sh` for anyone who does need it there.

## Testing

- `bash -n` on all four scripts.
- Verified the empty-vs-set `RPC_HEADERS_ARGS` array expansion under `set -u`.
- End-to-end proof against a mock gateway that 401s without the header: `cast chain-id` and a real `forge test` with `vm.createSelectFork` both fail with a 401 when hitting the mock directly, and both succeed when routed through `with-rpc-header-proxy.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
